### PR TITLE
Remove unused oot import

### DIFF
--- a/worlds/pmd_eos/__init__.py
+++ b/worlds/pmd_eos/__init__.py
@@ -8,7 +8,6 @@ import settings
 import random
 from typing import List, Dict, Set, Any
 
-import worlds.oot
 from .Items import (EOSItem, item_table, item_frequencies, item_table_by_id, item_table_by_groups,
                     filler_item_table, filler_item_weights, trap_item_table, trap_item_weights,
                     exclusive_filler_item_table, exclusive_filler_item_weights, legendary_pool_dict, filler_items,


### PR DESCRIPTION
Assuming this was an IDE tab mistake as it's not used anywhere. And this breaks loading pmd_eos in environments where oot is missing.
