### PR TITLE
Ruff format

### DIFF
--- a/worlds/pmd_eos/Client.py
+++ b/worlds/pmd_eos/Client.py
@@ -5,8 +5,7 @@ import re
 
 from BaseClasses import ItemClassification
 from NetUtils import ClientStatus
-from .Locations import location_Dict_by_id, location_dict_by_start_id, \
-    location_table_by_groups
+from .Locations import location_Dict_by_id, location_dict_by_start_id, location_table_by_groups
 from .Items import item_table_by_id, lootbox_table, item_table_by_groups
 from .DeathMessages import death_message_list, death_message_weights
 from random import Random
@@ -38,7 +37,7 @@ class EoSClient(BizHawkClient):
     ram_mem_domain = "Main RAM"
     goal_complete = False
     bag_given = False
-    #Macguffins = relic fragment shards
+    # Macguffins = relic fragment shards
     macguffins_collected = 0
     macguffin_unlock_amount = 0
     instruments_collected = 0
@@ -48,7 +47,7 @@ class EoSClient(BizHawkClient):
     skypeaks_open = 0
     aegis_seals = 0
     dialga_complete = False
-    #item_boxes_collected: List[ItemData] = []
+    # item_boxes_collected: List[ItemData] = []
     random: Random = Random()
     outside_deathlink = 0
     deathlink_sender = ""
@@ -70,19 +69,22 @@ class EoSClient(BizHawkClient):
         self.room = 0
         self.local_events = []
 
-    async def update_received_items(self, ctx: "BizHawkClientContext", received_items_offset, received_index,
-                                    i) -> None:
+    async def update_received_items(
+        self, ctx: "BizHawkClientContext", received_items_offset, received_index, i
+    ) -> None:
         # write the received index to the rom to save where we are at with the queue
         await bizhawk.write(
             ctx.bizhawk_ctx,
             [
-                (received_items_offset, [(received_index + i + 1) // 0x100, (received_index + i + 1) % 0x100],
-                 self.ram_mem_domain),
-            ]
+                (
+                    received_items_offset,
+                    [(received_index + i + 1) // 0x100, (received_index + i + 1) % 0x100],
+                    self.ram_mem_domain,
+                ),
+            ],
         )
 
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
-
         try:
             # Check ROM name/patch version
             rom_name_bytes = await bizhawk.read(ctx.bizhawk_ctx, [(0x3FFA80, 16, self.ram_mem_domain)])
@@ -104,9 +106,9 @@ class EoSClient(BizHawkClient):
         name_bytes = (await bizhawk.read(ctx.bizhawk_ctx, [(0x3DE000, 16, self.ram_mem_domain)]))[0]
         name = bytes([byte for byte in name_bytes if byte != 0]).decode("cp1252")
 
-        #NEED TO UPDATE THIS
+        # NEED TO UPDATE THIS
         self.player_name = name
-        #self.macguffin_unlock_amount = ctx.slot_data["ShardFragmentAmount"]
+        # self.macguffin_unlock_amount = ctx.slot_data["ShardFragmentAmount"]
 
         for i in range(25):
             self.checked_dungeon_flags[i] = []
@@ -133,13 +135,12 @@ class EoSClient(BizHawkClient):
             self.deathlink_sender = args["data"]["source"]
             if "cause" in args["data"]:
                 self.deathlink_message = args["data"]["cause"]
-                #self.deathlink_message = "Died from unknown causes"
-                #logger.info(args["data"]["cause"])
+                # self.deathlink_message = "Died from unknown causes"
+                # logger.info(args["data"]["cause"])
             else:
                 self.deathlink_message = "Died from unknown causes"
 
     async def game_watcher(self, ctx: "BizHawkClientContext") -> None:
-
         mission_start_id = 1000
         try:
             if ctx.server_seed_name is None:
@@ -172,22 +173,25 @@ class EoSClient(BizHawkClient):
                     )
                 except IndexError:
                     self.logger.info(
-                        "You are playing on a server version older than 0.3.1 so a server version cannot be found" +
-                        " OR something else went wrong")
+                        "You are playing on a server version older than 0.3.1 so a server version cannot be found"
+                        + " OR something else went wrong"
+                    )
                 except TypeError:
                     self.logger.info(
-                        "You are playing on a server version older than 0.3.1 so a server version cannot be found" +
-                        " OR something else went wrong")
+                        "You are playing on a server version older than 0.3.1 so a server version cannot be found"
+                        + " OR something else went wrong"
+                    )
                 except KeyError:
                     self.logger.info(
-                        "You are playing on a server version older than 0.3.1 so a server version cannot be found" +
-                        " OR something else went wrong")
+                        "You are playing on a server version older than 0.3.1 so a server version cannot be found"
+                        + " OR something else went wrong"
+                    )
                 self.logger.info(
                     "You are currently playing on the Archipelago Pokemon Mystery Dungeon: Explorer's of Sky version "
                     + self.client_version
                 )
                 self.seed_verify = True
-            #if 310 not in ctx.locations_info:
+            # if 310 not in ctx.locations_info:
             #    await ctx.send_msgs(
             #        [{
             #            "cmd": "LocationScouts",
@@ -195,73 +199,98 @@ class EoSClient(BizHawkClient):
             #        }]
             #    )
             if (self.player_name + "GenericStorage") not in ctx.stored_data:
-                await (ctx.send_msgs(
+                await ctx.send_msgs(
                     [
-                        #{"cmd": "Set",
+                        # {"cmd": "Set",
                         # "key": self.player_name + "Dungeon Missions",
                         # "default": {location: 0 for location in location_table_by_groups["Mission"]},
                         # "want_reply": True,
                         # "operations": [{"operation": "update", "value": {}}]
                         # },
-                        #{"cmd": "Set",
+                        # {"cmd": "Set",
                         # "key": self.player_name + "Dungeon Outlaws",
                         # "default": {location: 0 for location in location_table_by_groups["Mission"]},
                         # "want_reply": True,
                         # "operations": [{"operation": "update", "value": {}}]
                         # },
-                        {"cmd": "Set",
-                         "key": self.player_name + "Item Boxes Collected",
-                         "default": {0: []},
-                         "want_reply": True,
-                         "operations": [{"operation": "default", "value": {0: []}}]
-                         },
-                        {"cmd": "Set",
-                         "key": self.player_name + "Legendaries Recruited",
-                         "default": {0: []},
-                         "want_reply": True,
-                         "operations": [{"operation": "default", "value": {0: []}}]
-                         },
-                        {"cmd": "Set",
-                         "key": self.player_name + "Hinted Hints",
-                         "default": {0: []},
-                         "want_reply": True,
-                         "operations": [{"operation": "default", "value": {0: []}}]
-                         },
-                        {"cmd": "Set",
-                         "key": self.player_name + "GenericStorage",
-                         "default": {"goal_complete": False, "bag_given": False, "macguffins_collected": 0,
-                                     "macguffin_unlock_amount": 0, "instruments_collected": 0,
-                                     "dialga_complete": False, "skypeaks_open": 0, "aegis_seals": 0,
-                                     "spinda_events": 0, "spinda_drinks": 0, "box_number": 0},
-                         "want_reply": True,
-                         "operations": [{"operation": "default",
-                                         "value": {"goal_complete": False, "bag_given": False,
-                                                   "macguffins_collected": 0, "macguffin_unlock_amount": 0,
-                                                   "instruments_collected": 0,
-                                                   "dialga_complete": False, "skypeaks_open": 0,
-                                                   "aegis_seals": 0, "spinda_events": 0, "spinda_drinks": 0,
-                                                   "box_number": 0}}]
-                         }
-                    ]))
+                        {
+                            "cmd": "Set",
+                            "key": self.player_name + "Item Boxes Collected",
+                            "default": {0: []},
+                            "want_reply": True,
+                            "operations": [{"operation": "default", "value": {0: []}}],
+                        },
+                        {
+                            "cmd": "Set",
+                            "key": self.player_name + "Legendaries Recruited",
+                            "default": {0: []},
+                            "want_reply": True,
+                            "operations": [{"operation": "default", "value": {0: []}}],
+                        },
+                        {
+                            "cmd": "Set",
+                            "key": self.player_name + "Hinted Hints",
+                            "default": {0: []},
+                            "want_reply": True,
+                            "operations": [{"operation": "default", "value": {0: []}}],
+                        },
+                        {
+                            "cmd": "Set",
+                            "key": self.player_name + "GenericStorage",
+                            "default": {
+                                "goal_complete": False,
+                                "bag_given": False,
+                                "macguffins_collected": 0,
+                                "macguffin_unlock_amount": 0,
+                                "instruments_collected": 0,
+                                "dialga_complete": False,
+                                "skypeaks_open": 0,
+                                "aegis_seals": 0,
+                                "spinda_events": 0,
+                                "spinda_drinks": 0,
+                                "box_number": 0,
+                            },
+                            "want_reply": True,
+                            "operations": [
+                                {
+                                    "operation": "default",
+                                    "value": {
+                                        "goal_complete": False,
+                                        "bag_given": False,
+                                        "macguffins_collected": 0,
+                                        "macguffin_unlock_amount": 0,
+                                        "instruments_collected": 0,
+                                        "dialga_complete": False,
+                                        "skypeaks_open": 0,
+                                        "aegis_seals": 0,
+                                        "spinda_events": 0,
+                                        "spinda_drinks": 0,
+                                        "box_number": 0,
+                                    },
+                                }
+                            ],
+                        },
+                    ]
+                )
                 await asyncio.sleep(0.1)
 
             item_boxes_collected: List[Dict] = []
             legendaries_recruited: List[Dict] = []
-            open_list_total_offset: int = await (self.load_script_variable_raw(0x4F, ctx))
-            conquest_list_total_offset: int = await (self.load_script_variable_raw(0x52, ctx))
-            scenario_balance_offset = await (self.load_script_variable_raw(0x13, ctx))
-            performance_progress_offset = await (self.load_script_variable_raw(0x4E, ctx))
-            scenario_subx_offset = await (self.load_script_variable_raw(0x5, ctx))
-            received_items_offset = await (self.load_script_variable_raw(0x16, ctx))
-            scenario_main_offset = await (self.load_script_variable_raw(0x3, ctx))
-            scenario_main_bitfield_offset = await (self.load_script_variable_raw(0x11, ctx))
-            special_episode_offset = await (self.load_script_variable_raw(0x4B, ctx))
-            item_backup_offset = await (self.load_script_variable_raw(0x64, ctx))
-            dungeon_enter_index_offset = await (self.load_script_variable_raw(0x29, ctx))
-            scenario_talk_bitfield_offset = await (self.load_script_variable_raw(0x12, ctx))
-            event_local_offset = await (self.load_script_variable_raw(0x5C, ctx))
-            recycle_amount_offset = await (self.load_script_variable_raw(0x6C, ctx))
-            pelipper_received_counter_offset = await (self.load_script_variable_raw(0x1, ctx))
+            open_list_total_offset: int = await self.load_script_variable_raw(0x4F, ctx)
+            conquest_list_total_offset: int = await self.load_script_variable_raw(0x52, ctx)
+            scenario_balance_offset = await self.load_script_variable_raw(0x13, ctx)
+            performance_progress_offset = await self.load_script_variable_raw(0x4E, ctx)
+            scenario_subx_offset = await self.load_script_variable_raw(0x5, ctx)
+            received_items_offset = await self.load_script_variable_raw(0x16, ctx)
+            scenario_main_offset = await self.load_script_variable_raw(0x3, ctx)
+            scenario_main_bitfield_offset = await self.load_script_variable_raw(0x11, ctx)
+            special_episode_offset = await self.load_script_variable_raw(0x4B, ctx)
+            item_backup_offset = await self.load_script_variable_raw(0x64, ctx)
+            dungeon_enter_index_offset = await self.load_script_variable_raw(0x29, ctx)
+            scenario_talk_bitfield_offset = await self.load_script_variable_raw(0x12, ctx)
+            event_local_offset = await self.load_script_variable_raw(0x5C, ctx)
+            recycle_amount_offset = await self.load_script_variable_raw(0x6C, ctx)
+            pelipper_received_counter_offset = await self.load_script_variable_raw(0x1, ctx)
             bank_gold_offset = 0x2A5504  # await (self.load_script_variable_raw(0x3D, ctx))
             player_gold_offset = 0x2A54F8
             custom_save_area_offset = 0x3B0000
@@ -296,7 +325,7 @@ class EoSClient(BizHawkClient):
                     self.logger.info("hint locations not initialized. Please tell Cryptic if you see this")
 
             # if (self.player_name + "Dungeon Missions") in ctx.stored_data:
-                # dungeon_missions_dict = ctx.stored_data[self.player_name + "Dungeon Missions"]
+            # dungeon_missions_dict = ctx.stored_data[self.player_name + "Dungeon Missions"]
             # else:
             #     dungeon_missions_dict = {}
             #     return
@@ -336,7 +365,6 @@ class EoSClient(BizHawkClient):
                 self.item_box_count = max(stored["box_number"], self.item_box_count)
 
             else:
-
                 return
 
             if ctx.slot_data:
@@ -351,7 +379,7 @@ class EoSClient(BizHawkClient):
             if not self.required_instruments or self.required_instruments == 0:
                 self.required_instruments = ctx.slot_data["RequiredInstruments"]
 
-            #if not ctx.locations_info:
+            # if not ctx.locations_info:
             #    await (ctx.send_msgs(
             #        [
             #            {"cmd": "LocationScouts",
@@ -396,7 +424,7 @@ class EoSClient(BizHawkClient):
                     (sky_peaks_offset, 1, self.ram_mem_domain),  # Sky Peaks check
                     # (dimensional_scream_info_offset, 0x51, self.ram_mem_domain),
                     (legendaries_in_rom_offset, 1, self.ram_mem_domain),
-                ]
+                ],
             )
             # make sure we are actually on the start screen before checking items and such
             scenario_main_list = read_state[6]
@@ -408,19 +436,17 @@ class EoSClient(BizHawkClient):
                         main_game_unlocked = main_game_unlocked | 0x1
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
-                            [
-                                (main_game_unlocked_offset, int.to_bytes(main_game_unlocked),
-                                 self.ram_mem_domain)],
+                            [(main_game_unlocked_offset, int.to_bytes(main_game_unlocked), self.ram_mem_domain)],
                         )
             if int.from_bytes(scenario_main_list) == 0:
                 return
-            #is_running = await self.is_game_running(ctx)
+            # is_running = await self.is_game_running(ctx)
             LOADED_OVERLAY_GROUP_1 = 0xAFAD4
             overlay_groups = await bizhawk.read(ctx.bizhawk_ctx, [(LOADED_OVERLAY_GROUP_1, 8, self.ram_mem_domain)])
             group1 = int.from_bytes(overlay_groups[0][0:4], "little")
             group2 = int.from_bytes(overlay_groups[0][4:8], "little")
             if group2 == 0x2:
-                is_running = (group1 == 13 or group1 == 14)
+                is_running = group1 == 13 or group1 == 14
             else:
                 is_running = False
             if not is_running:
@@ -430,31 +456,31 @@ class EoSClient(BizHawkClient):
                 self.macguffin_unlock_amount = ctx.slot_data["ShardFragmentAmount"]
 
             # read the state of the dungeon lists
-            open_list: array.array[int] = array.array('i', [item for item in read_state[1]])
-            conquest_list: array.array[int] = array.array('i', [item for item in read_state[0]])
-            scenario_balance_byte = array.array('i', [item for item in read_state[2]])
-            performance_progress_bitfield: array.array[int] = array.array('i', [item for item in read_state[3]])
-            scenario_subx_bitfield: array.array[int] = array.array('i', [item for item in read_state[4]])
+            open_list: array.array[int] = array.array("i", [item for item in read_state[1]])
+            conquest_list: array.array[int] = array.array("i", [item for item in read_state[0]])
+            scenario_balance_byte = array.array("i", [item for item in read_state[2]])
+            performance_progress_bitfield: array.array[int] = array.array("i", [item for item in read_state[3]])
+            scenario_subx_bitfield: array.array[int] = array.array("i", [item for item in read_state[4]])
             received_index = int.from_bytes(read_state[5])
             special_episode_bitfield = int.from_bytes(read_state[7])
-            scenario_main_bitfield_list: array.array[int] = array.array('i', [item for item in read_state[8]])
-            item_backup_bytes: array.array[int] = array.array('i', [item for item in read_state[9]])
+            scenario_main_bitfield_list: array.array[int] = array.array("i", [item for item in read_state[8]])
+            item_backup_bytes: array.array[int] = array.array("i", [item for item in read_state[9]])
             scenario_talk_bitfield_248_list = int.from_bytes(read_state[10])
             event_local_num = int.from_bytes(read_state[12])
             dungeon_enter_index = int.from_bytes(read_state[11], "little")
             deathlink_receiver_bit = int.from_bytes(read_state[13])
             deathlink_sender_bit = int.from_bytes(read_state[14])
             deathlink_message_from_sky = ""
-            #deathlink_ally_death_message = read_state[16].decode("cp1252")
-            #deathlink_ally_name = read_state[17].decode("cp1252")
-            hintable_items = array.array('i', [item for item in read_state[18]])
+            # deathlink_ally_death_message = read_state[16].decode("cp1252")
+            # deathlink_ally_name = read_state[17].decode("cp1252")
+            hintable_items = array.array("i", [item for item in read_state[18]])
             bank_gold_amount = int.from_bytes(read_state[19], "little")
             player_gold_amount = int.from_bytes(read_state[20], "little")
             locs_to_send = set()
             relic_shards_amount = int.from_bytes(read_state[21])
             instruments_amount = int.from_bytes(read_state[22])
 
-            spinda_drinks_ram = array.array('i', [item for item in read_state[24]])
+            spinda_drinks_ram = array.array("i", [item for item in read_state[24]])
             scenario_talk_bitfield_240_list = int.from_bytes(read_state[25])
             bag_upgrade_value = int.from_bytes(read_state[26])
             recycle_amount = int.from_bytes(read_state[27], "little")
@@ -471,16 +497,15 @@ class EoSClient(BizHawkClient):
                     item_memory_offset = 0
                     if ctx.slot_data["SkyPeakType"] == 1:  # progressive
                         if self.skypeaks_open >= 11:
-                            self.logger.info(
-                                "Max Sky Peaks reached, not sending any more to rom"
-                            )
+                            self.logger.info("Max Sky Peaks reached, not sending any more to rom")
                         elif sky_peaks_ram == self.skypeaks_open:
                             self.skypeaks_open += 1
                             sky_peaks_ram += 1
                             self.logger.info(
-                                "The Sky Peak count from AP is " + str(self.skypeaks_open) +
-                                "\nAnd the Sky Peaks written to the ROM should now be: " + str(
-                                    sky_peaks_ram)
+                                "The Sky Peak count from AP is "
+                                + str(self.skypeaks_open)
+                                + "\nAnd the Sky Peaks written to the ROM should now be: "
+                                + str(sky_peaks_ram)
                             )
                         elif sky_peaks_ram > self.skypeaks_open:
                             # uhhhh I don't know how this could happen? Also what do I do????
@@ -490,24 +515,27 @@ class EoSClient(BizHawkClient):
                             self.skypeaks_open += 1
                             sky_peaks_ram += 1
                             self.logger.info(
-                                "Something Weird Happened Please tell Cryptic if you see this " +
-                                "\nThe Sky Peak count from AP was " + str(old_sky_peaks) +
-                                "\nAnd the Sky Peaks read from the rom was: " + str(
-                                    rom_old_sky) +
-                                "\nThe Sky Peak count from AP is " + str(self.skypeaks_open) +
-                                "\nAnd the Sky Peaks written to the ROM should now be: " + str(
-                                    sky_peaks_ram)
+                                "Something Weird Happened Please tell Cryptic if you see this "
+                                + "\nThe Sky Peak count from AP was "
+                                + str(old_sky_peaks)
+                                + "\nAnd the Sky Peaks read from the rom was: "
+                                + str(rom_old_sky)
+                                + "\nThe Sky Peak count from AP is "
+                                + str(self.skypeaks_open)
+                                + "\nAnd the Sky Peaks written to the ROM should now be: "
+                                + str(sky_peaks_ram)
                             )
                         else:
                             sky_peaks_ram += 1
                             self.logger.info(
-                                "The Rom decided to be lower than the AP count probably due to save states " +
-                                "\nThe Sky Peak count from AP is " + str(self.skypeaks_open) +
-                                "\nAnd the Sky Peaks written to the ROM should now be: " + str(
-                                    sky_peaks_ram)
+                                "The Rom decided to be lower than the AP count probably due to save states "
+                                + "\nThe Sky Peak count from AP is "
+                                + str(self.skypeaks_open)
+                                + "\nAnd the Sky Peaks written to the ROM should now be: "
+                                + str(sky_peaks_ram)
                             )
 
-                        #self.skypeaks_open += 1
+                        # self.skypeaks_open += 1
                         item_memory_offset = 0x6E + sky_peaks_ram
                     elif ctx.slot_data["SkyPeakType"] == 2:  # all random
                         item_memory_offset = item_data.memory_offset
@@ -526,10 +554,12 @@ class EoSClient(BizHawkClient):
                                 await bizhawk.write(
                                     ctx.bizhawk_ctx,
                                     [
-                                        (open_list_total_offset + sig_digit, int.to_bytes(write_byte),
-                                         self.ram_mem_domain)
+                                        (
+                                            open_list_total_offset + sig_digit,
+                                            int.to_bytes(write_byte),
+                                            self.ram_mem_domain,
+                                        )
                                     ],
-
                                 )
 
                         await self.update_received_items(ctx, received_items_offset, received_index, i)
@@ -544,22 +574,22 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (open_list_total_offset + sig_digit, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                    (sky_peaks_offset, int.to_bytes(sky_peaks_ram),
-                                     self.ram_mem_domain)],
-
+                                    (open_list_total_offset + sig_digit, int.to_bytes(write_byte), self.ram_mem_domain),
+                                    (sky_peaks_offset, int.to_bytes(sky_peaks_ram), self.ram_mem_domain),
+                                ],
                             )
 
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
-                    await (ctx.send_msgs(
+                    await ctx.send_msgs(
                         [
-                            {"cmd": "Set",
-                             "key": self.player_name + "GenericStorage",
-                             "want_reply": True,
-                             "operations": [{"operation": "update", "value": {"skypeaks_open": self.skypeaks_open}}]
-                             }
-                        ]))
+                            {
+                                "cmd": "Set",
+                                "key": self.player_name + "GenericStorage",
+                                "want_reply": True,
+                                "operations": [{"operation": "update", "value": {"skypeaks_open": self.skypeaks_open}}],
+                            }
+                        ]
+                    )
                     await asyncio.sleep(0.1)
 
                 elif item_data.name == "Main Game Unlock":
@@ -573,10 +603,16 @@ class EoSClient(BizHawkClient):
                     #   )
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
 
-                elif (("EarlyDungeons" in item_data.group) or ("LateDungeons" in item_data.group)
-                      or ("Dojo Dungeons" in item_data.group) or ("BossDungeons" in item_data.group)
-                      or ("ExtraDungeons" in item_data.group) or ("RuleDungeons" in item_data.group)
-                      or ("Final Dojo" in item_data.group) or ("Dungeon" in item_data.group)):
+                elif (
+                    ("EarlyDungeons" in item_data.group)
+                    or ("LateDungeons" in item_data.group)
+                    or ("Dojo Dungeons" in item_data.group)
+                    or ("BossDungeons" in item_data.group)
+                    or ("ExtraDungeons" in item_data.group)
+                    or ("RuleDungeons" in item_data.group)
+                    or ("Final Dojo" in item_data.group)
+                    or ("Dungeon" in item_data.group)
+                ):
                     item_memory_offset = item_data.memory_offset
                     # Since our open list is a byte array and our memory offset is bit based
                     # We have to grab our significant byte digits
@@ -588,9 +624,7 @@ class EoSClient(BizHawkClient):
                         open_list[sig_digit] = write_byte
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
-                            [
-                                (open_list_total_offset + sig_digit, int.to_bytes(write_byte),
-                                 self.ram_mem_domain)],
+                            [(open_list_total_offset + sig_digit, int.to_bytes(write_byte), self.ram_mem_domain)],
                         )
 
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
@@ -603,9 +637,7 @@ class EoSClient(BizHawkClient):
                         special_episode_bitfield = write_byte
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
-                            [
-                                (special_episode_offset, int.to_bytes(write_byte),
-                                 self.ram_mem_domain)],
+                            [(special_episode_offset, int.to_bytes(write_byte), self.ram_mem_domain)],
                         )
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
                 elif "Generic" in item_data.group:
@@ -616,9 +648,8 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
 
                         else:
@@ -635,9 +666,8 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (bag_upgrade_offset, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (bag_upgrade_offset, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
 
                     elif item_data.name == "Secret of the Waterfall":
@@ -647,15 +677,14 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         else:
-                            await self.add_money(ctx, 500, player_gold_amount, bank_gold_amount,
-                                                 player_gold_offset, bank_gold_offset)
-                            self.logger.info(
-                                "But you already own one so instead you get 500 Poké")
+                            await self.add_money(
+                                ctx, 500, player_gold_amount, bank_gold_amount, player_gold_offset, bank_gold_offset
+                            )
+                            self.logger.info("But you already own one so instead you get 500 Poké")
 
                     elif item_data.name == "Chatot Repellent":
                         if ((performance_progress_bitfield[3] >> 1) & 1) == 0:
@@ -664,15 +693,14 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         else:
-                            await self.add_money(ctx, 500, player_gold_amount, bank_gold_amount,
-                                                 player_gold_offset, bank_gold_offset)
-                            self.logger.info(
-                                "But you already own one so instead you get 500 Poké")
+                            await self.add_money(
+                                ctx, 500, player_gold_amount, bank_gold_amount, player_gold_offset, bank_gold_offset
+                            )
+                            self.logger.info("But you already own one so instead you get 500 Poké")
                     elif item_data.name == "Sky Jukebox":
                         if ((performance_progress_bitfield[3] >> 2) & 1) == 0:
                             write_byte = performance_progress_bitfield[3] | (0x1 << 2)
@@ -680,15 +708,14 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         else:
-                            await self.add_money(ctx, 500, player_gold_amount, bank_gold_amount,
-                                                 player_gold_offset, bank_gold_offset)
-                            self.logger.info(
-                                "But you already own one so instead you get 500 Poké")
+                            await self.add_money(
+                                ctx, 500, player_gold_amount, bank_gold_amount, player_gold_offset, bank_gold_offset
+                            )
+                            self.logger.info("But you already own one so instead you get 500 Poké")
 
                     elif item_data.name == "Recruitment Sensor":
                         if ((performance_progress_bitfield[3] >> 5) & 1) == 0:
@@ -697,15 +724,14 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         else:
-                            await self.add_money(ctx, 500, player_gold_amount, bank_gold_amount,
-                                                 player_gold_offset, bank_gold_offset)
-                            self.logger.info(
-                                "But you already own one so instead you get 500 Poké")
+                            await self.add_money(
+                                ctx, 500, player_gold_amount, bank_gold_amount, player_gold_offset, bank_gold_offset
+                            )
+                            self.logger.info("But you already own one so instead you get 500 Poké")
 
                     elif item_data.name == "Mystery of the Quicksand":
                         if ((performance_progress_bitfield[3] >> 4) & 1) == 0:
@@ -714,15 +740,14 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x3, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         else:
-                            await self.add_money(ctx, 500, player_gold_amount, bank_gold_amount,
-                                                 player_gold_offset, bank_gold_offset)
-                            self.logger.info(
-                                "But you already own one so instead you get 500 Poké")
+                            await self.add_money(
+                                ctx, 500, player_gold_amount, bank_gold_amount, player_gold_offset, bank_gold_offset
+                            )
+                            self.logger.info("But you already own one so instead you get 500 Poké")
 
                     elif item_data.name == "Hero Evolution":
                         write_byte = performance_progress_bitfield[1] | (0x1 << 2)
@@ -730,9 +755,8 @@ class EoSClient(BizHawkClient):
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
                             [
-                                (performance_progress_offset + 0x1, int.to_bytes(write_byte),
-                                 self.ram_mem_domain),
-                            ]
+                                (performance_progress_offset + 0x1, int.to_bytes(write_byte), self.ram_mem_domain),
+                            ],
                         )
                     elif item_data.name == "Recruit Evolution":
                         write_byte = performance_progress_bitfield[0] | (0x1 << 6)
@@ -740,9 +764,8 @@ class EoSClient(BizHawkClient):
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
                             [
-                                (performance_progress_offset, int.to_bytes(write_byte),
-                                 self.ram_mem_domain),
-                            ]
+                                (performance_progress_offset, int.to_bytes(write_byte), self.ram_mem_domain),
+                            ],
                         )
                     elif item_data.name == "Recruitment":
                         write_byte = performance_progress_bitfield[0] | (0x1 << 5)
@@ -750,9 +773,8 @@ class EoSClient(BizHawkClient):
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
                             [
-                                (performance_progress_offset, int.to_bytes(write_byte),
-                                 self.ram_mem_domain),
-                            ]
+                                (performance_progress_offset, int.to_bytes(write_byte), self.ram_mem_domain),
+                            ],
                         )
 
                     elif item_data.name == "Formation Control":
@@ -763,11 +785,9 @@ class EoSClient(BizHawkClient):
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
                             [
-                                (performance_progress_offset, int.to_bytes(write_byte),
-                                 self.ram_mem_domain),
-                                (performance_progress_offset + 0x2, int.to_bytes(write_byte2),
-                                 self.ram_mem_domain),
-                            ]
+                                (performance_progress_offset, int.to_bytes(write_byte), self.ram_mem_domain),
+                                (performance_progress_offset + 0x2, int.to_bytes(write_byte2), self.ram_mem_domain),
+                            ],
                         )
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
                 elif "Money" in item_data.group:
@@ -777,7 +797,7 @@ class EoSClient(BizHawkClient):
                             player_gold_amount = 0
                     else:
                         player_gold_amount += item_data.memory_offset
-                    #bank_gold_amount += item_data.memory_offset
+                    # bank_gold_amount += item_data.memory_offset
                     if player_gold_amount > 99999:
                         extra_money = player_gold_amount - 99999
                         player_gold_amount = 99999
@@ -787,10 +807,8 @@ class EoSClient(BizHawkClient):
                     await bizhawk.write(
                         ctx.bizhawk_ctx,
                         [
-                            (bank_gold_offset, int.to_bytes(bank_gold_amount, 4, "little"),
-                             self.ram_mem_domain),
-                            (player_gold_offset, int.to_bytes(player_gold_amount, 4, "little"),
-                             self.ram_mem_domain)
+                            (bank_gold_offset, int.to_bytes(bank_gold_amount, 4, "little"), self.ram_mem_domain),
+                            (player_gold_offset, int.to_bytes(player_gold_amount, 4, "little"), self.ram_mem_domain),
                         ],
                     )
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
@@ -802,8 +820,7 @@ class EoSClient(BizHawkClient):
                     await bizhawk.write(
                         ctx.bizhawk_ctx,
                         [
-                            (recycle_amount_offset, int.to_bytes(recycle_amount, 4, "little"),
-                             self.ram_mem_domain),
+                            (recycle_amount_offset, int.to_bytes(recycle_amount, 4, "little"), self.ram_mem_domain),
                         ],
                     )
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
@@ -812,9 +829,7 @@ class EoSClient(BizHawkClient):
                         write_byte = performance_progress_bitfield[2] | (0x1 << 6)
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
-                            [
-                                (performance_progress_offset + 0x2, int.to_bytes(write_byte),
-                                 self.ram_mem_domain)],
+                            [(performance_progress_offset + 0x2, int.to_bytes(write_byte), self.ram_mem_domain)],
                         )
                         await self.update_received_items(ctx, received_items_offset, received_index, i)
                 elif "Macguffin" in item_data.group:
@@ -828,14 +843,10 @@ class EoSClient(BizHawkClient):
                         if rfs_count >= 20:
                             self.logger.info("Max Relic Fragment Shards Reached")
                             rfs_count = 20
-                        self.logger.info(
-                            "The Relic Fragment Shard count from AP is " + str(rfs_count)
-                        )
+                        self.logger.info("The Relic Fragment Shard count from AP is " + str(rfs_count))
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
-                            [
-                                (relic_shards_offset, int.to_bytes(rfs_count),
-                                 self.ram_mem_domain)],
+                            [(relic_shards_offset, int.to_bytes(rfs_count), self.ram_mem_domain)],
                         )
                         await asyncio.sleep(0.1)
 
@@ -850,8 +861,12 @@ class EoSClient(BizHawkClient):
                                 await bizhawk.write(
                                     ctx.bizhawk_ctx,
                                     [
-                                        (open_list_total_offset + sig_digit, int.to_bytes(write_byte),
-                                         self.ram_mem_domain)],
+                                        (
+                                            open_list_total_offset + sig_digit,
+                                            int.to_bytes(write_byte),
+                                            self.ram_mem_domain,
+                                        )
+                                    ],
                                 )
 
                             await asyncio.sleep(0.1)
@@ -863,7 +878,8 @@ class EoSClient(BizHawkClient):
                         continue
                     else:
                         item_boxes_collected += [
-                            {"name": item_data.name, "id": item_data.id, "memory_offset": item_data.memory_offset}]
+                            {"name": item_data.name, "id": item_data.id, "memory_offset": item_data.memory_offset}
+                        ]
                         self.item_box_count = received_index + i
                         if "Instrument" in item_data.group:
                             # JUST RECOUNT THE INSTRUMENTS GOSH DARN IT
@@ -880,35 +896,36 @@ class EoSClient(BizHawkClient):
                             self.instruments_collected = instrument_count
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
-                                [
-                                    (instruments_offset, int.to_bytes(instrument_count),
-                                     self.ram_mem_domain)],
+                                [(instruments_offset, int.to_bytes(instrument_count), self.ram_mem_domain)],
                             )
-                            self.logger.info(
-                                        "The Instrument count from AP is " + str(instrument_count)
-                                    )
+                            self.logger.info("The Instrument count from AP is " + str(instrument_count))
 
-                    await (ctx.send_msgs(
+                    await ctx.send_msgs(
                         [
-                            {"cmd": "Set",
-                             "key": self.player_name + "Item Boxes Collected",
-                             "want_reply": True,
-                             "operations": [{"operation": "replace", "value": {0: item_boxes_collected}}]
-                             },
-                        ]))
+                            {
+                                "cmd": "Set",
+                                "key": self.player_name + "Item Boxes Collected",
+                                "want_reply": True,
+                                "operations": [{"operation": "replace", "value": {0: item_boxes_collected}}],
+                            },
+                        ]
+                    )
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
                 elif "Legendary" in item_data.group:
                     legendaries_recruited += [
-                        {"name": item_data.name, "id": item_data.id, "memory_offset": item_data.memory_offset}]
+                        {"name": item_data.name, "id": item_data.id, "memory_offset": item_data.memory_offset}
+                    ]
 
-                    await (ctx.send_msgs(
+                    await ctx.send_msgs(
                         [
-                            {"cmd": "Set",
-                             "key": self.player_name + "Legendaries Recruited",
-                             "want_reply": True,
-                             "operations": [{"operation": "replace", "value": {0: legendaries_recruited}}]
-                             }
-                        ]))
+                            {
+                                "cmd": "Set",
+                                "key": self.player_name + "Legendaries Recruited",
+                                "want_reply": True,
+                                "operations": [{"operation": "replace", "value": {0: legendaries_recruited}}],
+                            }
+                        ]
+                    )
 
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
 
@@ -928,20 +945,20 @@ class EoSClient(BizHawkClient):
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
                             [
-                                (scenario_main_bitfield_offset + 0x5, int.to_bytes(write_byte),
-                                 self.ram_mem_domain),
-                            ]
+                                (scenario_main_bitfield_offset + 0x5, int.to_bytes(write_byte), self.ram_mem_domain),
+                            ],
                         )
 
-                    await (ctx.send_msgs(
+                    await ctx.send_msgs(
                         [
-                            {"cmd": "Set",
-                             "key": self.player_name + "GenericStorage",
-                             "want_reply": True,
-                             "operations": [{"operation": "update", "value":
-                                 {"aegis_seals": self.aegis_seals}}]
-                             }
-                        ]))
+                            {
+                                "cmd": "Set",
+                                "key": self.player_name + "GenericStorage",
+                                "want_reply": True,
+                                "operations": [{"operation": "update", "value": {"aegis_seals": self.aegis_seals}}],
+                            }
+                        ]
+                    )
                     await self.update_received_items(ctx, received_items_offset, received_index, i)
 
                 elif "Trap" in item_data.group:
@@ -952,9 +969,8 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x4, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         await self.update_received_items(ctx, received_items_offset, received_index, i)
                     elif item_data.name == "Get Unowned!":
@@ -964,9 +980,8 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x4, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         await self.update_received_items(ctx, received_items_offset, received_index, i)
                     elif item_data.name == "Nap Time!":
@@ -976,9 +991,8 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (scenario_main_bitfield_offset, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (scenario_main_bitfield_offset, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         await self.update_received_items(ctx, received_items_offset, received_index, i)
                     elif item_data.name == "Sentry Duty!":  # 34
@@ -988,9 +1002,8 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x4, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         await self.update_received_items(ctx, received_items_offset, received_index, i)
                     elif item_data.name == "Touch Grass":  # 36
@@ -1000,9 +1013,8 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (performance_progress_offset + 0x4, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         await self.update_received_items(ctx, received_items_offset, received_index, i)
                     elif "DungeonTrap" in item_data.group:
@@ -1012,9 +1024,8 @@ class EoSClient(BizHawkClient):
                             await bizhawk.write(
                                 ctx.bizhawk_ctx,
                                 [
-                                    (dungeon_traps_bitfield_offset, int.to_bytes(write_byte),
-                                     self.ram_mem_domain),
-                                ]
+                                    (dungeon_traps_bitfield_offset, int.to_bytes(write_byte), self.ram_mem_domain),
+                                ],
                             )
                         await self.update_received_items(ctx, received_items_offset, received_index, i)
             # Check for set location flags in dungeon list
@@ -1053,9 +1064,9 @@ class EoSClient(BizHawkClient):
             if ((scenario_talk_bitfield_248_list >> 5) & 1) == 1:  # if normal mission
                 # read dungeon enter index
                 mission_status_read = await bizhawk.read(
-                    ctx.bizhawk_ctx,
-                    [(mission_status_offset, 384, self.ram_mem_domain)])
-                mission_status = array.array('i', [item for item in mission_status_read[0]])
+                    ctx.bizhawk_ctx, [(mission_status_offset, 384, self.ram_mem_domain)]
+                )
+                mission_status = array.array("i", [item for item in mission_status_read[0]])
                 for i in range(192):
                     if i not in location_dict_by_start_id:
                         continue
@@ -1063,25 +1074,23 @@ class EoSClient(BizHawkClient):
                         if "Mission" in location_dict_by_start_id[i].group:
                             location_name = location_dict_by_start_id[i].name
                             location_id = location_dict_by_start_id[i].id
-                            #dungeons_complete = dungeon_missions_dict[location_name]
+                            # dungeons_complete = dungeon_missions_dict[location_name]
                             current_missions_completed = mission_status[2 * i]
 
                             if "Early" in location_dict_by_start_id[i].group:
                                 for k in range(current_missions_completed):
                                     if k < ctx.slot_data["EarlyMissionsAmount"]:
-                                        locs_to_send.add(location_id + mission_start_id + (
-                                                100 * location_id) + k)
-                                        #dungeon_missions_dict[location_name] += 1
+                                        locs_to_send.add(location_id + mission_start_id + (100 * location_id) + k)
+                                        # dungeon_missions_dict[location_name] += 1
                                         # location.id + mission_start_id + (100 * i) + j`
 
                             elif "Late" in location_dict_by_start_id[i].group:
                                 for k in range(current_missions_completed):
                                     if k < ctx.slot_data["LateMissionsAmount"]:
-                                        locs_to_send.add(location_id + mission_start_id + (
-                                                100 * location_id) + k)
-                                        #dungeon_missions_dict[location_name] += 1
+                                        locs_to_send.add(location_id + mission_start_id + (100 * location_id) + k)
+                                        # dungeon_missions_dict[location_name] += 1
                                         # location.id + mission_start_id + (100 * i) + j
-                #await (ctx.send_msgs(
+                # await (ctx.send_msgs(
                 #    [
                 #        {"cmd": "Set",
                 #         "key": self.player_name + "Dungeon Missions",
@@ -1094,17 +1103,20 @@ class EoSClient(BizHawkClient):
                 await bizhawk.write(
                     ctx.bizhawk_ctx,
                     [
-                        (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                         self.ram_mem_domain),
-                    ]
+                        (
+                            scenario_talk_bitfield_offset + 0x1F,
+                            int.to_bytes(scenario_talk_bitfield_248_list),
+                            self.ram_mem_domain,
+                        ),
+                    ],
                 )
                 await asyncio.sleep(0.1)
             elif ((scenario_talk_bitfield_248_list >> 4) & 1) == 1:  # if outlaw mission
                 # read dungeon enter index
                 mission_status_read = await bizhawk.read(
-                    ctx.bizhawk_ctx,
-                    [(mission_status_offset, 384, self.ram_mem_domain)])
-                mission_status = array.array('i', [item for item in mission_status_read[0]])
+                    ctx.bizhawk_ctx, [(mission_status_offset, 384, self.ram_mem_domain)]
+                )
+                mission_status = array.array("i", [item for item in mission_status_read[0]])
                 # checking every dungeon
                 for i in range(192):
                     # check to make sure it's the dungeon start not a random place in the dungeon
@@ -1116,25 +1128,23 @@ class EoSClient(BizHawkClient):
                             location_name = location_dict_by_start_id[i].name
                             location_id = location_dict_by_start_id[i].id
                             # grab the current status of the dungeon outlaws
-                            #dungeons_complete = dungeon_outlaws_dict[location_name]
+                            # dungeons_complete = dungeon_outlaws_dict[location_name]
                             # grab from rom how many missions are complete for the specified dungeon
                             current_missions_completed = mission_status[2 * i + 1]
 
                             if "Early" in location_dict_by_start_id[i].group:
                                 for k in range(current_missions_completed):
                                     if k < ctx.slot_data["EarlyOutlawsAmount"]:
-                                        locs_to_send.add(location_id + mission_start_id + 50 + (
-                                                100 * location_id) + k)
-                                        #dungeon_outlaws_dict[location_name] += 1
+                                        locs_to_send.add(location_id + mission_start_id + 50 + (100 * location_id) + k)
+                                        # dungeon_outlaws_dict[location_name] += 1
                                         # location.id + mission_start_id + (100 * i) + j`
                             elif "Late" in location_dict_by_start_id[i].group:
                                 for k in range(current_missions_completed):
                                     if k < ctx.slot_data["LateOutlawsAmount"]:
-                                        locs_to_send.add(location_id + mission_start_id + 50 + (
-                                                100 * location_id) + k)
-                                        #dungeon_outlaws_dict[location_name] += 1
+                                        locs_to_send.add(location_id + mission_start_id + 50 + (100 * location_id) + k)
+                                        # dungeon_outlaws_dict[location_name] += 1
                                         # location.id + mission_start_id + (100 * i) + j
-                #await (ctx.send_msgs(
+                # await (ctx.send_msgs(
                 #    [
                 #        {"cmd": "Set",
                 #         "key": self.player_name + "Dungeon Outlaws",
@@ -1146,9 +1156,12 @@ class EoSClient(BizHawkClient):
                 await bizhawk.write(
                     ctx.bizhawk_ctx,
                     [
-                        (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                         self.ram_mem_domain),
-                    ]
+                        (
+                            scenario_talk_bitfield_offset + 0x1F,
+                            int.to_bytes(scenario_talk_bitfield_248_list),
+                            self.ram_mem_domain,
+                        ),
+                    ],
                 )
                 await asyncio.sleep(0.1)
 
@@ -1167,21 +1180,18 @@ class EoSClient(BizHawkClient):
                         if j not in self.hints_hinted:
                             self.hints_hinted.append(j)
                             hints_to_send += [j]
-                await (ctx.send_msgs(
-                    [
-                        {"cmd": "LocationScouts",
-                         "locations": hints_to_send,
-                         "create_as_hint": 2
-                         }]))
+                await ctx.send_msgs([{"cmd": "LocationScouts", "locations": hints_to_send, "create_as_hint": 2}])
                 self.hint_issue = False
-                await (ctx.send_msgs(
+                await ctx.send_msgs(
                     [
-                        {"cmd": "Set",
-                         "key": self.player_name + "Hinted Hints",
-                         "want_reply": True,
-                         "operations": [{"operation": "update", "value": {0: self.hints_hinted}}]
-                         }
-                    ]))
+                        {
+                            "cmd": "Set",
+                            "key": self.player_name + "Hinted Hints",
+                            "want_reply": True,
+                            "operations": [{"operation": "update", "value": {0: self.hints_hinted}}],
+                        }
+                    ]
+                )
 
             except IndexError:
                 if not self.hint_issue:
@@ -1199,32 +1209,31 @@ class EoSClient(BizHawkClient):
                     deathlink_message_from_sky = read_state[15].decode("cp1252").split(chr(0))[0]
                     deathlink_message_from_sky = re.sub(r"\[.*?]", "", deathlink_message_from_sky)
                     lappyint = self.random.randint(1, 100)
-                    #deathlink_message_from_sky = deathlink_message_from_sky.replace("byan", "by an")
+                    # deathlink_message_from_sky = deathlink_message_from_sky.replace("byan", "by an")
                     if lappyint <= 20:
                         death_string_list = self.random.sample(death_message_list, k=1, counts=death_message_weights)
                         death_string = death_string_list[0].death_string
                         await ctx.send_death(f"{ctx.player_names[ctx.slot]}{death_string}")
                     else:
                         await ctx.send_death(f"{ctx.player_names[ctx.slot]}{deathlink_message_from_sky}")
-                await bizhawk.write(
-                    ctx.bizhawk_ctx,
-                    [
-                        (death_link_sender_offset, int.to_bytes(0), self.ram_mem_domain)
-                    ]
-                )
+                await bizhawk.write(ctx.bizhawk_ctx, [(death_link_sender_offset, int.to_bytes(0), self.ram_mem_domain)])
                 await asyncio.sleep(0.1)
             if self.outside_deathlink != 0:
-                write_message = str(self.deathlink_message).translate(trans_table).split(chr(0))[0].encode("cp1252")[
-                                0:128]
-                write_message2 = f"[CS:N]{str(self.deathlink_sender).translate(trans_table).split(chr(0))[0][0:18]}[CR]".encode(
-                    "cp1252")
+                write_message = (
+                    str(self.deathlink_message).translate(trans_table).split(chr(0))[0].encode("cp1252")[0:128]
+                )
+                write_message2 = (
+                    f"[CS:N]{str(self.deathlink_sender).translate(trans_table).split(chr(0))[0][0:18]}[CR]".encode(
+                        "cp1252"
+                    )
+                )
                 await bizhawk.write(
                     ctx.bizhawk_ctx,
                     [
                         (death_link_ally_death_message_offset, write_message, self.ram_mem_domain),
                         (death_link_ally_name_offset, write_message2, self.ram_mem_domain),
-                        (death_link_receiver_offset, int.to_bytes(1), self.ram_mem_domain)
-                    ]
+                        (death_link_receiver_offset, int.to_bytes(1), self.ram_mem_domain),
+                    ],
                 )
                 self.outside_deathlink -= 1
 
@@ -1238,9 +1247,7 @@ class EoSClient(BizHawkClient):
                     write_byte = open_list[sig_digit] | (1 << non_sig_digit)
                     await bizhawk.write(
                         ctx.bizhawk_ctx,
-                        [
-                            (open_list_total_offset + sig_digit, int.to_bytes(write_byte),
-                             self.ram_mem_domain)],
+                        [(open_list_total_offset + sig_digit, int.to_bytes(write_byte), self.ram_mem_domain)],
                     )
                     await asyncio.sleep(0.1)
 
@@ -1258,12 +1265,18 @@ class EoSClient(BizHawkClient):
                             ctx.bizhawk_ctx,
                             [
                                 (item_backup_offset, write_byte2, self.ram_mem_domain),
-                                (item_backup_offset + 0x2, int.to_bytes(0, byteorder="little", length=2),
-                                 self.ram_mem_domain),
+                                (
+                                    item_backup_offset + 0x2,
+                                    int.to_bytes(0, byteorder="little", length=2),
+                                    self.ram_mem_domain,
+                                ),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
-                                (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                 self.ram_mem_domain)
-                            ]
+                                (
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                            ],
                         )
                         await asyncio.sleep(0.1)
                     elif item_data["name"] in item_table_by_groups["Multi"]:
@@ -1275,13 +1288,18 @@ class EoSClient(BizHawkClient):
                             ctx.bizhawk_ctx,
                             [
                                 (item_backup_offset, write_byte2, self.ram_mem_domain),
-                                (item_backup_offset + 0x2, int.to_bytes(5, byteorder="little", length=2),
-                                 self.ram_mem_domain),
+                                (
+                                    item_backup_offset + 0x2,
+                                    int.to_bytes(5, byteorder="little", length=2),
+                                    self.ram_mem_domain,
+                                ),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
                                 (
-                                    scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                    self.ram_mem_domain)
-                            ]
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                            ],
                         )
                         await asyncio.sleep(0.1)
                     elif item_data["name"] in item_table_by_groups["Instrument"]:
@@ -1303,15 +1321,19 @@ class EoSClient(BizHawkClient):
                             ctx.bizhawk_ctx,
                             [
                                 (item_backup_offset, write_byte2, self.ram_mem_domain),
-                                (item_backup_offset + 0x2, int.to_bytes(0, byteorder="little", length=2),
-                                 self.ram_mem_domain),
+                                (
+                                    item_backup_offset + 0x2,
+                                    int.to_bytes(0, byteorder="little", length=2),
+                                    self.ram_mem_domain,
+                                ),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
-                                (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                 self.ram_mem_domain),
-                                (instruments_offset, int.to_bytes(instrument_count),
-                                 self.ram_mem_domain)
-
-                            ]
+                                (
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                                (instruments_offset, int.to_bytes(instrument_count), self.ram_mem_domain),
+                            ],
                         )
                         await asyncio.sleep(0.1)
 
@@ -1321,7 +1343,7 @@ class EoSClient(BizHawkClient):
 
                         write_byte3 = [item_data["memory_offset"] % 256, item_data["memory_offset"] // 256]
 
-                        write_byte2 = [0x16c % 256, 0x16c // 256]
+                        write_byte2 = [0x16C % 256, 0x16C // 256]
                         scenario_talk_bitfield_248_list = scenario_talk_bitfield_248_list & 0xFB
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
@@ -1330,9 +1352,11 @@ class EoSClient(BizHawkClient):
                                 (item_backup_offset + 0x2, write_byte3, self.ram_mem_domain),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
                                 (
-                                    scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                    self.ram_mem_domain)
-                            ]
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                            ],
                         )
                         await asyncio.sleep(0.1)
 
@@ -1354,15 +1378,21 @@ class EoSClient(BizHawkClient):
                                 (item_backup_offset, write_byte2, self.ram_mem_domain),
                                 (item_backup_offset + 0x2, write_byte3, self.ram_mem_domain),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
-                                (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                 self.ram_mem_domain)
-                            ]
+                                (
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                            ],
                         )
                         await asyncio.sleep(0.1)
 
             else:  # if we are dealing with items
-                if (item_boxes_collected and (pelipper_received_counter < len(item_boxes_collected))
-                        and (((scenario_talk_bitfield_248_list >> 2) & 1) == 1)):
+                if (
+                    item_boxes_collected
+                    and (pelipper_received_counter < len(item_boxes_collected))
+                    and (((scenario_talk_bitfield_248_list >> 2) & 1) == 1)
+                ):
                     # I have an item in my list and lappy is already done with the item in the queue,
                     # so add another item to queue and set performance progress to true
                     item_data = item_boxes_collected[pelipper_received_counter]
@@ -1375,12 +1405,18 @@ class EoSClient(BizHawkClient):
                             ctx.bizhawk_ctx,
                             [
                                 (item_backup_offset, write_byte2, self.ram_mem_domain),
-                                (item_backup_offset + 0x2, int.to_bytes(0, byteorder="little", length=2),
-                                 self.ram_mem_domain),
+                                (
+                                    item_backup_offset + 0x2,
+                                    int.to_bytes(0, byteorder="little", length=2),
+                                    self.ram_mem_domain,
+                                ),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
-                                (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                 self.ram_mem_domain)
-                            ]
+                                (
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                            ],
                         )
                         await asyncio.sleep(0.1)
                     elif item_data["name"] in item_table_by_groups["Multi"]:
@@ -1392,13 +1428,18 @@ class EoSClient(BizHawkClient):
                             ctx.bizhawk_ctx,
                             [
                                 (item_backup_offset, write_byte2, self.ram_mem_domain),
-                                (item_backup_offset + 0x2, int.to_bytes(5, byteorder="little", length=2),
-                                 self.ram_mem_domain),
+                                (
+                                    item_backup_offset + 0x2,
+                                    int.to_bytes(5, byteorder="little", length=2),
+                                    self.ram_mem_domain,
+                                ),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
                                 (
-                                    scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                    self.ram_mem_domain)
-                            ]
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                            ],
                         )
                         await asyncio.sleep(0.1)
                     elif item_data["name"] in item_table_by_groups["Instrument"]:
@@ -1420,14 +1461,19 @@ class EoSClient(BizHawkClient):
                             ctx.bizhawk_ctx,
                             [
                                 (item_backup_offset, write_byte2, self.ram_mem_domain),
-                                (item_backup_offset + 0x2, int.to_bytes(0, byteorder="little", length=2),
-                                 self.ram_mem_domain),
+                                (
+                                    item_backup_offset + 0x2,
+                                    int.to_bytes(0, byteorder="little", length=2),
+                                    self.ram_mem_domain,
+                                ),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
-                                (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                 self.ram_mem_domain),
-                                (instruments_offset, int.to_bytes(instrument_count),
-                                 self.ram_mem_domain)
-                            ]
+                                (
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                                (instruments_offset, int.to_bytes(instrument_count), self.ram_mem_domain),
+                            ],
                         )
                         await asyncio.sleep(0.1)
 
@@ -1437,7 +1483,7 @@ class EoSClient(BizHawkClient):
 
                         write_byte3 = [item_data["memory_offset"] % 256, item_data["memory_offset"] // 256]
 
-                        write_byte2 = [0x16c % 256, 0x16c // 256]
+                        write_byte2 = [0x16C % 256, 0x16C // 256]
                         scenario_talk_bitfield_248_list = scenario_talk_bitfield_248_list & 0xFB
                         await bizhawk.write(
                             ctx.bizhawk_ctx,
@@ -1446,9 +1492,11 @@ class EoSClient(BizHawkClient):
                                 (item_backup_offset + 0x2, write_byte3, self.ram_mem_domain),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
                                 (
-                                    scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                    self.ram_mem_domain)
-                            ]
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                            ],
                         )
                         await asyncio.sleep(0.1)
                     elif item_data["name"] in item_table_by_groups["Box"]:
@@ -1469,9 +1517,12 @@ class EoSClient(BizHawkClient):
                                 (item_backup_offset, write_byte2, self.ram_mem_domain),
                                 (item_backup_offset + 0x2, write_byte3, self.ram_mem_domain),
                                 (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
-                                (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                                 self.ram_mem_domain)
-                            ]
+                                (
+                                    scenario_talk_bitfield_offset + 0x1F,
+                                    int.to_bytes(scenario_talk_bitfield_248_list),
+                                    self.ram_mem_domain,
+                                ),
+                            ],
                         )
                         await asyncio.sleep(0.1)
 
@@ -1479,22 +1530,28 @@ class EoSClient(BizHawkClient):
                     # I don't have items in my list and lappy is done with the item,
                     # add a null to the queue and set performance progress to true
                     write_byte = performance_progress_bitfield[4] | (0x1 << 3)
-                    scenario_talk_bitfield_248_list = (scenario_talk_bitfield_248_list & 0xFB)
+                    scenario_talk_bitfield_248_list = scenario_talk_bitfield_248_list & 0xFB
                     await bizhawk.write(
                         ctx.bizhawk_ctx,
                         [
                             (item_backup_offset, [0, 0], self.ram_mem_domain),
                             (item_backup_offset + 0x2, [0, 0], self.ram_mem_domain),
                             (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
-                            (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                             self.ram_mem_domain)
-                        ]
+                            (
+                                scenario_talk_bitfield_offset + 0x1F,
+                                int.to_bytes(scenario_talk_bitfield_248_list),
+                                self.ram_mem_domain,
+                            ),
+                        ],
                     )
                     await asyncio.sleep(0.1)
 
             # if performance progress 37 is off, and we have a legendary to recruit, turn 37 on
-            if ((((performance_progress_bitfield[4] >> 5) & 1) == 0) and event_local_num != 22 and
-                    legendaries_recruited_amount < len(legendaries_recruited)):
+            if (
+                (((performance_progress_bitfield[4] >> 5) & 1) == 0)
+                and event_local_num != 22
+                and legendaries_recruited_amount < len(legendaries_recruited)
+            ):
                 write_byte = performance_progress_bitfield[4] | (0x1 << 5)
                 performance_progress_bitfield[4] = write_byte
 
@@ -1502,14 +1559,17 @@ class EoSClient(BizHawkClient):
                     ctx.bizhawk_ctx,
                     [
                         (performance_progress_offset + 0x4, int.to_bytes(write_byte), self.ram_mem_domain),
-                    ]
+                    ],
                 )
                 await asyncio.sleep(0.1)
 
             # if Scenario Talk 249 is on, edit event local with the index of the next legendary and then turn off
             # performance progress 37
-            if ((((scenario_talk_bitfield_248_list >> 1) & 1) == 1) and event_local_num == 22 and
-                    legendaries_recruited_amount < len(legendaries_recruited)):
+            if (
+                (((scenario_talk_bitfield_248_list >> 1) & 1) == 1)
+                and event_local_num == 22
+                and legendaries_recruited_amount < len(legendaries_recruited)
+            ):
                 item_data = legendaries_recruited[legendaries_recruited_amount]
                 legendaries_recruited_amount += 1
                 write_byte2 = item_data["memory_offset"]
@@ -1517,19 +1577,20 @@ class EoSClient(BizHawkClient):
                 await bizhawk.write(
                     ctx.bizhawk_ctx,
                     [
-
                         (event_local_offset, int.to_bytes(write_byte2), self.ram_mem_domain),
-                        (scenario_talk_bitfield_offset + 0x1F, int.to_bytes(scenario_talk_bitfield_248_list),
-                         self.ram_mem_domain),
-                        (legendaries_in_rom_offset, int.to_bytes(legendaries_recruited_amount), self.ram_mem_domain)
-                    ]
+                        (
+                            scenario_talk_bitfield_offset + 0x1F,
+                            int.to_bytes(scenario_talk_bitfield_248_list),
+                            self.ram_mem_domain,
+                        ),
+                        (legendaries_in_rom_offset, int.to_bytes(legendaries_recruited_amount), self.ram_mem_domain),
+                    ],
                 )
                 await asyncio.sleep(0.1)
 
             # Check for Spinda flag and release the spinda checks based on the amount in ram
             if ((scenario_talk_bitfield_240_list >> 7) & 1) == 1:
-
-                #if spinda_drinks_ram[0] > self.spinda_events:
+                # if spinda_drinks_ram[0] > self.spinda_events:
                 spinda_events_start_id = 900
                 for spindaid in range(spinda_drinks_ram[0]):
                     locs_to_send.add(spinda_events_start_id + spindaid)
@@ -1544,30 +1605,43 @@ class EoSClient(BizHawkClient):
                 await bizhawk.write(
                     ctx.bizhawk_ctx,
                     [
-                        (scenario_talk_bitfield_offset + 0x1E, int.to_bytes(scenario_talk_bitfield_240_list),
-                         self.ram_mem_domain),
-                    ]
+                        (
+                            scenario_talk_bitfield_offset + 0x1E,
+                            int.to_bytes(scenario_talk_bitfield_240_list),
+                            self.ram_mem_domain,
+                        ),
+                    ],
                 )
 
             # send the locations checked to the server
             await ctx.check_locations(locs_to_send)
 
             # Update data storage
-            await (ctx.send_msgs(
+            await ctx.send_msgs(
                 [
-                    {"cmd": "Set",
-                     "key": self.player_name + "GenericStorage",
-                     "want_reply": True,
-                     "operations": [{"operation": "update", "value":
-                         {"goal_complete": self.goal_complete, "bag_given": self.bag_given,
-                          "macguffins_collected": self.macguffins_collected,
-                          "macguffin_unlock_amount": self.macguffin_unlock_amount,
-                          "instruments_collected": self.instruments_collected,
-                          "dialga_complete": self.dialga_complete, "skypeaks_open": self.skypeaks_open,
-                          "aegis_seals": self.aegis_seals,
-                          "box_number": self.item_box_count}}]
-                     }
-                ]))
+                    {
+                        "cmd": "Set",
+                        "key": self.player_name + "GenericStorage",
+                        "want_reply": True,
+                        "operations": [
+                            {
+                                "operation": "update",
+                                "value": {
+                                    "goal_complete": self.goal_complete,
+                                    "bag_given": self.bag_given,
+                                    "macguffins_collected": self.macguffins_collected,
+                                    "macguffin_unlock_amount": self.macguffin_unlock_amount,
+                                    "instruments_collected": self.instruments_collected,
+                                    "dialga_complete": self.dialga_complete,
+                                    "skypeaks_open": self.skypeaks_open,
+                                    "aegis_seals": self.aegis_seals,
+                                    "box_number": self.item_box_count,
+                                },
+                            }
+                        ],
+                    }
+                ]
+            )
             await asyncio.sleep(0.1)
 
             # Check for finishing the game and send the goal to the server
@@ -1583,33 +1657,44 @@ class EoSClient(BizHawkClient):
     async def load_script_variable_raw(self, var_id, ctx: "BizHawkClientContext") -> int:
         script_vars_values = 0x2AB9EC
         script_vars = 0x9DDF4
-        var_mem_offset = await bizhawk.read(ctx.bizhawk_ctx,
-                                            [((script_vars + (var_id << 0x4) + 0x4), 2, self.ram_mem_domain)])
+        var_mem_offset = await bizhawk.read(
+            ctx.bizhawk_ctx, [((script_vars + (var_id << 0x4) + 0x4), 2, self.ram_mem_domain)]
+        )
         return script_vars_values + int.from_bytes(var_mem_offset[0], "little")
 
     def unused(self, ctx):
-        (ctx.send_msgs(
-            [
-                {"cmd": "Set",
-                 "key": "Dungeon Missions",
-                 "default": {},
-                 "want_reply": True,
-                 "operations": [{"operation": "update", "value": {}}]
-                 }
-            ]
-        ))
+        (
+            ctx.send_msgs(
+                [
+                    {
+                        "cmd": "Set",
+                        "key": "Dungeon Missions",
+                        "default": {},
+                        "want_reply": True,
+                        "operations": [{"operation": "update", "value": {}}],
+                    }
+                ]
+            )
+        )
 
     async def is_game_running(self, ctx: "BizHawkClientContext") -> bool:
         LOADED_OVERLAY_GROUP_1 = 0xAF234
         overlay_groups = await bizhawk.read(ctx.bizhawk_ctx, [(LOADED_OVERLAY_GROUP_1, 8, self.ram_mem_domain)])
         group1 = int.from_bytes(overlay_groups[0][0:4], "little")
         group2 = int.from_bytes(overlay_groups[0][4:8], "little")
-        if (group2 == 0x2):
+        if group2 == 0x2:
             return group1 == 13 or group1 == 14
         return False
 
-    async def add_money(self, ctx: "BizHawkClientContext", money, player_gold_amount, bank_gold_amount,
-                        player_gold_offset, bank_gold_offset):
+    async def add_money(
+        self,
+        ctx: "BizHawkClientContext",
+        money,
+        player_gold_amount,
+        bank_gold_amount,
+        player_gold_offset,
+        bank_gold_offset,
+    ):
         player_gold_amount += money
         # bank_gold_amount += item_data.memory_offset
         if player_gold_amount > 99999:
@@ -1621,9 +1706,7 @@ class EoSClient(BizHawkClient):
         await bizhawk.write(
             ctx.bizhawk_ctx,
             [
-                (bank_gold_offset, int.to_bytes(bank_gold_amount, 4, "little"),
-                 self.ram_mem_domain),
-                (player_gold_offset, int.to_bytes(player_gold_amount, 4, "little"),
-                 self.ram_mem_domain)
+                (bank_gold_offset, int.to_bytes(bank_gold_amount, 4, "little"), self.ram_mem_domain),
+                (player_gold_offset, int.to_bytes(player_gold_amount, 4, "little"), self.ram_mem_domain),
             ],
         )

--- a/worlds/pmd_eos/DeathMessages.py
+++ b/worlds/pmd_eos/DeathMessages.py
@@ -1,4 +1,3 @@
-
 from typing import List, NamedTuple
 
 common_weight = 40

--- a/worlds/pmd_eos/Items.py
+++ b/worlds/pmd_eos/Items.py
@@ -24,7 +24,7 @@ class EOSItem(Item):
 # Make a dictionary that separates the item table based on the different groups for being able to search for all items
 # under a specific group
 def get_item_table_by_groups() -> Dict[str, set[str]]:
-    #groups: Set[str] = set()
+    # groups: Set[str] = set()
     new_dict: Dict[str, set[str]] = {}
     for item_name in item_table:
         if item_table[item_name].group:
@@ -44,107 +44,155 @@ EOS_item_table = [
     # "Test Dungeon"0, ItemClassification.progression, ["Unique", "Dungeons"],0x0), Test Dungeon does not actually exist
     # ItemData("Beach Cave", 1, ItemClassification.progression, 1, ["Unique", "EarlyDungeons"], 0x1), Beach cave is open
     # by default
-    ItemData("Drenched Bluff", 3, ItemClassification.progression, 3, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x3),
+    ItemData(
+        "Drenched Bluff", 3, ItemClassification.progression, 3, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x3
+    ),
     ItemData("Mt. Bristle", 4, ItemClassification.progression, 4, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x4),
-    ItemData("Waterfall Cave", 6, ItemClassification.progression, 6, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x6),
+    ItemData(
+        "Waterfall Cave", 6, ItemClassification.progression, 6, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x6
+    ),
     ItemData("Apple Woods", 7, ItemClassification.progression, 7, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x7),
     ItemData("Craggy Coast", 8, ItemClassification.progression, 8, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x8),
     ItemData("Side Path", 9, ItemClassification.progression, 9, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x9),
     ItemData("Mt. Horn", 10, ItemClassification.progression, 10, ["Unique", "EarlyDungeons", "MissionDungeons"], 0xA),
     ItemData("Rock Path", 11, ItemClassification.progression, 11, ["Unique", "EarlyDungeons", "MissionDungeons"], 0xB),
-    ItemData("Foggy Forest", 12, ItemClassification.progression, 12, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0xC),
-    ItemData("Forest Path", 13, ItemClassification.progression, 13, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0xD),
+    ItemData(
+        "Foggy Forest", 12, ItemClassification.progression, 12, ["Unique", "EarlyDungeons", "MissionDungeons"], 0xC
+    ),
+    ItemData(
+        "Forest Path", 13, ItemClassification.progression, 13, ["Unique", "EarlyDungeons", "MissionDungeons"], 0xD
+    ),
     ItemData("Steam Cave", 14, ItemClassification.progression, 14, ["Unique", "EarlyDungeons", "MissionDungeons"], 0xE),
-    ItemData("Amp Plains", 17, ItemClassification.progression, 17, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0X11),
-    ItemData("Northern Desert", 20, ItemClassification.progression, 20, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x14),
-    ItemData("Quicksand Cave", 21, ItemClassification.progression, 21, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x15),
-    ItemData("Crystal Cave", 24, ItemClassification.progression, 24, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x18),
-    ItemData("Crystal Crossing", 25, ItemClassification.progression, 25, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x19),
-    ItemData("Chasm Cave", 27, ItemClassification.progression, 27, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x1B),
+    ItemData(
+        "Amp Plains", 17, ItemClassification.progression, 17, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x11
+    ),
+    ItemData(
+        "Northern Desert", 20, ItemClassification.progression, 20, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x14
+    ),
+    ItemData(
+        "Quicksand Cave", 21, ItemClassification.progression, 21, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x15
+    ),
+    ItemData(
+        "Crystal Cave", 24, ItemClassification.progression, 24, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x18
+    ),
+    ItemData(
+        "Crystal Crossing", 25, ItemClassification.progression, 25, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x19
+    ),
+    ItemData(
+        "Chasm Cave", 27, ItemClassification.progression, 27, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x1B
+    ),
     ItemData("Dark Hill", 28, ItemClassification.progression, 28, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x1C),
-    ItemData("Sealed Ruin", 29, ItemClassification.progression, 29, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x1D),
-    ItemData("Dusk Forest", 32, ItemClassification.progression, 32, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x20),
-    ItemData("Deep Dusk Forest", 33, ItemClassification.progression, 33, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x21),
-    ItemData("Treeshroud Forest", 34, ItemClassification.progression, 34,
-             ["Unique", "EarlyDungeons", "MissionDungeons"], 0x22),
-    ItemData("Brine Cave", 35, ItemClassification.progression, 35, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x23),
+    ItemData(
+        "Sealed Ruin", 29, ItemClassification.progression, 29, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x1D
+    ),
+    ItemData(
+        "Dusk Forest", 32, ItemClassification.progression, 32, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x20
+    ),
+    ItemData(
+        "Deep Dusk Forest", 33, ItemClassification.progression, 33, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x21
+    ),
+    ItemData(
+        "Treeshroud Forest",
+        34,
+        ItemClassification.progression,
+        34,
+        ["Unique", "EarlyDungeons", "MissionDungeons"],
+        0x22,
+    ),
+    ItemData(
+        "Brine Cave", 35, ItemClassification.progression, 35, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x23
+    ),
     # Hidden Land is opened by relic fragment shards (Macguffins)
     # ItemData("Hidden Land", 38, ItemClassification.progression, 38, ["Unique", "BossDungeons"], 0x26),
     ItemData("Temporal Tower", 41, ItemClassification.progression, 41, ["Unique", "BossDungeons"], 0x29),
-    ItemData("Mystifying Forest", 44, ItemClassification.progression, 44, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x2C),
-    ItemData("Blizzard Island", 46, ItemClassification.progression, 46, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x2E),
-    ItemData("Crevice Cave", 47, ItemClassification.progression, 47, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x2F),
-    ItemData("Surrounded Sea", 50, ItemClassification.progression, 50, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x32),
-    ItemData("Miracle Sea", 51, ItemClassification.progression, 51, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x33),
+    ItemData(
+        "Mystifying Forest", 44, ItemClassification.progression, 44, ["Unique", "LateDungeons", "MissionDungeons"], 0x2C
+    ),
+    ItemData(
+        "Blizzard Island", 46, ItemClassification.progression, 46, ["Unique", "LateDungeons", "MissionDungeons"], 0x2E
+    ),
+    ItemData(
+        "Crevice Cave", 47, ItemClassification.progression, 47, ["Unique", "LateDungeons", "MissionDungeons"], 0x2F
+    ),
+    ItemData(
+        "Surrounded Sea", 50, ItemClassification.progression, 50, ["Unique", "LateDungeons", "MissionDungeons"], 0x32
+    ),
+    ItemData(
+        "Miracle Sea", 51, ItemClassification.progression, 51, ["Unique", "LateDungeons", "MissionDungeons"], 0x33
+    ),
     ItemData("Ice Aegis Cave", 54, ItemClassification.progression, 54, ["Unique", "LateDungeons"], 0x36),
-    ItemData("Mt. Travail", 62, ItemClassification.progression, 62, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x3E),
-    ItemData("The Nightmare", 63, ItemClassification.progression, 63, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x3F),
-    ItemData("Spacial Rift", 64, ItemClassification.progression, 64, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x40),
+    ItemData(
+        "Mt. Travail", 62, ItemClassification.progression, 62, ["Unique", "LateDungeons", "MissionDungeons"], 0x3E
+    ),
+    ItemData(
+        "The Nightmare", 63, ItemClassification.progression, 63, ["Unique", "LateDungeons", "MissionDungeons"], 0x3F
+    ),
+    ItemData(
+        "Spacial Rift", 64, ItemClassification.progression, 64, ["Unique", "LateDungeons", "MissionDungeons"], 0x40
+    ),
     # Dark Crater auto opens if you get the amount of instruments needed
     # ItemData("Dark Crater", 67, ItemClassification.progression, 67, ["Unique", "BossDungeons"], 0x43),
-    ItemData("Concealed Ruins", 70, ItemClassification.progression, 70, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x46),
-    ItemData("Marine Resort", 72, ItemClassification.progression, 72, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x48),
-    ItemData("Bottomless Sea", 73, ItemClassification.progression, 73, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x49),
-    ItemData("Shimmer Desert", 75, ItemClassification.progression, 75, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x4B),
-    ItemData("Mt. Avalanche", 77, ItemClassification.progression, 77, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x4D),
-    ItemData("Giant Volcano", 79, ItemClassification.progression, 79, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x4F),
-    ItemData("World Abyss", 81, ItemClassification.progression, 81, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x51),
-    ItemData("Sky Stairway", 83, ItemClassification.progression, 83, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x53),
-    ItemData("Mystery Jungle", 85, ItemClassification.progression, 85, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x55),
-    ItemData("Serenity River", 87, ItemClassification.progression, 87, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x57),
-    ItemData("Landslide Cave", 88, ItemClassification.progression, 88, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x58),
-    ItemData("Lush Prairie", 89, ItemClassification.progression, 89, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x59),
-    ItemData("Tiny Meadow", 90, ItemClassification.progression, 90, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x5A),
-    ItemData("Labyrinth Cave", 91, ItemClassification.progression, 91, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x5B),
-    ItemData("Oran Forest", 92, ItemClassification.progression, 92, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0x5C),
+    ItemData(
+        "Concealed Ruins", 70, ItemClassification.progression, 70, ["Unique", "LateDungeons", "MissionDungeons"], 0x46
+    ),
+    ItemData(
+        "Marine Resort", 72, ItemClassification.progression, 72, ["Unique", "LateDungeons", "MissionDungeons"], 0x48
+    ),
+    ItemData(
+        "Bottomless Sea", 73, ItemClassification.progression, 73, ["Unique", "LateDungeons", "MissionDungeons"], 0x49
+    ),
+    ItemData(
+        "Shimmer Desert", 75, ItemClassification.progression, 75, ["Unique", "LateDungeons", "MissionDungeons"], 0x4B
+    ),
+    ItemData(
+        "Mt. Avalanche", 77, ItemClassification.progression, 77, ["Unique", "LateDungeons", "MissionDungeons"], 0x4D
+    ),
+    ItemData(
+        "Giant Volcano", 79, ItemClassification.progression, 79, ["Unique", "LateDungeons", "MissionDungeons"], 0x4F
+    ),
+    ItemData(
+        "World Abyss", 81, ItemClassification.progression, 81, ["Unique", "LateDungeons", "MissionDungeons"], 0x51
+    ),
+    ItemData(
+        "Sky Stairway", 83, ItemClassification.progression, 83, ["Unique", "LateDungeons", "MissionDungeons"], 0x53
+    ),
+    ItemData(
+        "Mystery Jungle", 85, ItemClassification.progression, 85, ["Unique", "LateDungeons", "MissionDungeons"], 0x55
+    ),
+    ItemData(
+        "Serenity River", 87, ItemClassification.progression, 87, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x57
+    ),
+    ItemData(
+        "Landslide Cave", 88, ItemClassification.progression, 88, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x58
+    ),
+    ItemData(
+        "Lush Prairie", 89, ItemClassification.progression, 89, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x59
+    ),
+    ItemData(
+        "Tiny Meadow", 90, ItemClassification.progression, 90, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x5A
+    ),
+    ItemData(
+        "Labyrinth Cave", 91, ItemClassification.progression, 91, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x5B
+    ),
+    ItemData(
+        "Oran Forest", 92, ItemClassification.progression, 92, ["Unique", "EarlyDungeons", "MissionDungeons"], 0x5C
+    ),
     ItemData("Lake Afar", 93, ItemClassification.progression, 93, ["Unique", "LateDungeons", "MissionDungeons"], 0x5D),
-    ItemData("Happy Outlook", 94, ItemClassification.progression, 94, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x5E),
-    ItemData("Mt. Mistral", 95, ItemClassification.progression, 95, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x5F),
-    ItemData("Shimmer Hill", 96, ItemClassification.progression, 96, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x60),
-    ItemData("Lost Wilderness", 97, ItemClassification.progression, 97, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x61),
-    ItemData("Midnight Forest", 98, ItemClassification.progression, 98, ["Unique", "LateDungeons", "MissionDungeons"],
-             0x62),
+    ItemData(
+        "Happy Outlook", 94, ItemClassification.progression, 94, ["Unique", "LateDungeons", "MissionDungeons"], 0x5E
+    ),
+    ItemData(
+        "Mt. Mistral", 95, ItemClassification.progression, 95, ["Unique", "LateDungeons", "MissionDungeons"], 0x5F
+    ),
+    ItemData(
+        "Shimmer Hill", 96, ItemClassification.progression, 96, ["Unique", "LateDungeons", "MissionDungeons"], 0x60
+    ),
+    ItemData(
+        "Lost Wilderness", 97, ItemClassification.progression, 97, ["Unique", "LateDungeons", "MissionDungeons"], 0x61
+    ),
+    ItemData(
+        "Midnight Forest", 98, ItemClassification.progression, 98, ["Unique", "LateDungeons", "MissionDungeons"], 0x62
+    ),
     ItemData("Zero Isle North", 99, ItemClassification.progression, 99, ["Unique", "RuleDungeons"], 0x63),
     ItemData("Zero Isle East", 100, ItemClassification.progression, 100, ["Unique", "RuleDungeons"], 0x64),
     ItemData("Zero Isle West", 101, ItemClassification.progression, 101, ["Unique", "RuleDungeons"], 0x65),
@@ -155,41 +203,101 @@ EOS_item_table = [
     ItemData("Treacherous Waters", 108, ItemClassification.progression, 108, ["Unique", "RuleDungeons"], 0x6C),
     ItemData("Southeastern Islands", 109, ItemClassification.progression, 109, ["Unique", "RuleDungeons"], 0x6D),
     ItemData("Inferno Cave", 110, ItemClassification.progression, 110, ["Unique", "RuleDungeons"], 0x6E),
-    ItemData("1st Station Pass", 111, ItemClassification.progression, 111,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x6F),
-    ItemData("2nd Station Pass", 112, ItemClassification.progression, 112,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x70),
-    ItemData("3rd Station Pass", 113, ItemClassification.progression, 113,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x71),
-    ItemData("4th Station Pass", 114, ItemClassification.progression, 114,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x72),
-    ItemData("5th Station Pass", 115, ItemClassification.progression, 115,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x73),
-    ItemData("6th Station Pass", 116, ItemClassification.progression, 116,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x74),
-    ItemData("7th Station Pass", 117, ItemClassification.progression, 117,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x75),
-    ItemData("8th Station Pass", 118, ItemClassification.progression, 118,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x76),
-    ItemData("9th Station Pass", 119, ItemClassification.progression, 119,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x77),
-    ItemData("Sky Peak Summit Pass", 120, ItemClassification.progression, 120,
-             ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"], 0x78),
+    ItemData(
+        "1st Station Pass",
+        111,
+        ItemClassification.progression,
+        111,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x6F,
+    ),
+    ItemData(
+        "2nd Station Pass",
+        112,
+        ItemClassification.progression,
+        112,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x70,
+    ),
+    ItemData(
+        "3rd Station Pass",
+        113,
+        ItemClassification.progression,
+        113,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x71,
+    ),
+    ItemData(
+        "4th Station Pass",
+        114,
+        ItemClassification.progression,
+        114,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x72,
+    ),
+    ItemData(
+        "5th Station Pass",
+        115,
+        ItemClassification.progression,
+        115,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x73,
+    ),
+    ItemData(
+        "6th Station Pass",
+        116,
+        ItemClassification.progression,
+        116,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x74,
+    ),
+    ItemData(
+        "7th Station Pass",
+        117,
+        ItemClassification.progression,
+        117,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x75,
+    ),
+    ItemData(
+        "8th Station Pass",
+        118,
+        ItemClassification.progression,
+        118,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x76,
+    ),
+    ItemData(
+        "9th Station Pass",
+        119,
+        ItemClassification.progression,
+        119,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x77,
+    ),
+    ItemData(
+        "Sky Peak Summit Pass",
+        120,
+        ItemClassification.progression,
+        120,
+        ["Unique", "LateDungeons", "SkyPeak", "MissionDungeons"],
+        0x78,
+    ),
     # Boss parts of the dungeons do not need to be unlocked by the client
     # ItemData("5th Station Clearing", 121, ItemClassification.progression, 121,
     #        ["Unique", "LateDungeons", "MissionDungeons"], 0x79),
     # ItemData("Sky Peak Summit", 122, ItemClassification.progression, 122,
     #        ["Unique", "LateDungeons", "MissionDungeons"], 0x7A),
-
     # SPECIAL EPISODES // All special episodes are unlocked by their beginning dungeon
-    ItemData("Bidoof\'s Wish", 123, ItemClassification.progression, 123, ["Unique", "Special Dungeons"], 0x0),
+    ItemData("Bidoof's Wish", 123, ItemClassification.progression, 123, ["Unique", "Special Dungeons"], 0x0),
     # ItemData("SE Star Cave", 123, ItemClassification.useful, 123, ["Unique", "Special Dungeons"], 0x7B),
     ItemData("Igglybuff the Prodigy", 128, ItemClassification.progression, 128, ["Unique", "Special Dungeons"], 0x1),
     # ItemData("Murky Forest", 128, ItemClassification.useful, 128, ["Unique", "Special Dungeons"], 0x80),
     # ItemData("Eastern Cave", 129, ItemClassification.useful, 129, ["Unique", "Special Dungeons"], 0x81),
     # ItemData("Fortune Ravine", 130, ItemClassification.useful, 130, ["Unique", "Special Dungeons"], 0x82),
-    ItemData("In the Future of Darkness", 133, ItemClassification.progression, 133, ["Unique", "Special Dungeons"],
-             0x4),
+    ItemData(
+        "In the Future of Darkness", 133, ItemClassification.progression, 133, ["Unique", "Special Dungeons"], 0x4
+    ),
     # ItemData("Barren Valley", 133, ItemClassification.useful, 133, ["Unique", "Special Dungeons"], 0x85),
     # ItemData("Dark Wasteland", 136, ItemClassification.useful, 136, ["Unique", "Special Dungeons"], 0x88),
     # ItemData("Temporal Tower2", 137, ItemClassification.useful, 137, ["Unique", "Special Dungeons"], 0x89),
@@ -206,14 +314,13 @@ EOS_item_table = [
     # ItemData("Limestone Cavern", 155, ItemClassification.useful, 155, ["Unique", "Special Dungeons"], 0x9B),
     ItemData('Today\'s "Oh My Gosh"', 158, ItemClassification.progression, 158, ["Unique", "Special Dungeons"], 0x2),
     # ItemData("Spring Cave", 158, ItemClassification.useful, 158, ["Unique", "Special Dungeons"], 0x9E),
-
     # PMD EOS Why do you have three things to open after the SEs >:(
-    ItemData("Star Cave", 174, ItemClassification.progression, 174, ["Unique", "EarlyDungeons", "MissionDungeons"],
-             0xAE),
+    ItemData(
+        "Star Cave", 174, ItemClassification.progression, 174, ["Unique", "EarlyDungeons", "MissionDungeons"], 0xAE
+    ),
     ItemData("Shaymin Village", 175, ItemClassification.useful, 175, ["Unique", "ExtraDungeons"], 0xAF),
     ItemData("Luminous Spring", 177, ItemClassification.useful, 177, ["Unique", "ExtraDungeons"], 0xB1),
     ItemData("Hot Spring", 178, ItemClassification.useful, 178, ["Unique", "ExtraDungeons"], 0xB2),
-
     # DOJO DUNGEONS
     ItemData("Dojo Normal/Fly Maze", 180, ItemClassification.progression, 180, ["Unique", "Dojo Dungeons"], 0xB4),
     ItemData("Dojo Dark/Fire Maze", 181, ItemClassification.progression, 181, ["Unique", "Dojo Dungeons"], 0xB5),
@@ -226,30 +333,22 @@ EOS_item_table = [
     ItemData("Dojo Dragon Maze", 188, ItemClassification.progression, 188, ["Unique", "Dojo Dungeons"], 0xBC),
     ItemData("Dojo Ghost Maze", 189, ItemClassification.progression, 189, ["Unique", "Dojo Dungeons"], 0xBD),
     ItemData("Dojo Final Maze", 191, ItemClassification.progression, 191, ["Unique", "Final Dojo"], 0xBF),  # 7 subareas
-
     # Macguffin for opening Hidden Land
     ItemData("Relic Fragment Shard", 200, ItemClassification.progression_skip_balancing, 200, ["Macguffin"], 0x00),
-
     # Item for the progressive sky peak option. Does not exist outside that option
     ItemData("Progressive Sky Peak", 201, ItemClassification.progression, 0, ["SkyPeak"], 0x00),
-
     # Seals for Aegis Cave. Unlock the ability to progress in the cave without getting cursed
     ItemData("Ice Seal", 203, ItemClassification.progression, 0, ["Aegis"], 0x00),
     ItemData("Rock Seal", 204, ItemClassification.progression, 0, ["Aegis"], 0x00),
     ItemData("Steel Seal", 205, ItemClassification.progression, 0, ["Aegis"], 0x00),
-
     # Progressive version of seals for Aegis Cave
     ItemData("Progressive Seal", 206, ItemClassification.progression, 0, ["Aegis"], 0x00),
-
     # Need an item that can get claimed to tell AP that victory has been accomplished. Just an event.
     ItemData("Victory", 300, ItemClassification.progression, 0, [], 0x00),
-
     # Progressively upgrade the player's bag
     ItemData("Bag Upgrade", 370, ItemClassification.progression, 0, ["ProgressiveBag", "Generic"], 0x00),
-
     # Secret rank which unlocks the ability to get the checks for recruiting legendaries late game
     ItemData("Secret Rank", 409, ItemClassification.progression, 0, ["Rank"], 0x0),
-
     # Useful Items to be put in the apworld
     ItemData("Mystery Part", 500, ItemClassification.useful, 0, ["Item", "Single"], 0xAD),
     ItemData("Secret Slab", 501, ItemClassification.useful, 0, ["Item", "Single"], 0xAE),
@@ -258,7 +357,6 @@ EOS_item_table = [
     ItemData("Golden Mask", 546, ItemClassification.useful, 0, ["Item", "Single"], 0x39),
     ItemData("Miracle Chest", 464, ItemClassification.useful, 0, ["Item", "Single"], 0x42),  # Boosts Exp
     ItemData("Wonder Chest", 465, ItemClassification.useful, 0, ["Item", "Single"], 0x43),  # Boosts Exp
-
     # LEGENDARIES
     ItemData("Regirock", 504, ItemClassification.useful, 0, ["Legendary"], 0x0),
     ItemData("Regice", 505, ItemClassification.useful, 0, ["Legendary"], 0x1),
@@ -282,7 +380,6 @@ EOS_item_table = [
     ItemData("Rayquaza", 523, ItemClassification.useful, 0, ["Legendary"], 0x13),
     ItemData("Kyogre", 524, ItemClassification.useful, 0, ["Legendary"], 0x14),
     ItemData("Shaymin", 525, ItemClassification.useful, 0, ["Legendary"], 0x15),
-
     # Instruments which are also Macguffins for Dark Crater. Includes some extra instruments that we have added for fun
     # and flavor
     ItemData("Icy Flute", 526, ItemClassification.progression_skip_balancing, 0, ["Item", "Instrument"], 0x3B),
@@ -305,19 +402,15 @@ EOS_item_table = [
     ItemData("Psychic Cello", 543, ItemClassification.progression_skip_balancing, 0, ["Item", "Instrument"], 0x575),
     ItemData("Dragu-teki", 544, ItemClassification.progression_skip_balancing, 0, ["Item", "Instrument"], 0x576),
     ItemData("Steel Guitar", 545, ItemClassification.progression_skip_balancing, 0, ["Item", "Instrument"], 0x577),
-
     # Items that give the player an overall buff or ability to do something new in game
     ItemData("Hero Evolution", 550, ItemClassification.useful, 0, ["Generic"], 0),
     ItemData("Recruit Evolution", 551, ItemClassification.useful, 0, ["Generic"], 0),
     ItemData("Recruitment", 552, ItemClassification.useful, 0, ["Generic"], 0),
     ItemData("Formation Control", 553, ItemClassification.progression, 0, ["Generic"], 0),
-
     # Unlocking the main game for Special Episode Sanity
     ItemData("Main Game Unlock", 700, ItemClassification.progression, 0, [], 0),
-
     # Adding one team name trap so players can actually get their team name at leasst once in the game
     ItemData("Inspiration Strikes!!", 466, ItemClassification.useful, 0, ["Trap"], 0x0),
-
 ]
 filler_items = [
     # Item boxes as "loot boxes" as defined in a later section what they contain
@@ -332,10 +425,8 @@ filler_items = [
     ItemData("Cute Box", 309, ItemClassification.filler, 10, ["Item", "Box"], 0x189),
     # ItemData("Hard Box", 310, ItemClassification.filler, 10, ["Item", "Box"], 0x18C),
     # ItemData("Sinister Box", 311, ItemClassification.filler, 10, ["Item", "Box"], 0x18F),
-
     ItemData("Link Box", 312, ItemClassification.filler, 10, ["Item", "Single"], 0x16A),
     ItemData("Sky Gift", 313, ItemClassification.filler, 10, ["Item", "Single"], 0xB4),
-
     # MONEY
     ItemData("Poké x100", 560, ItemClassification.filler, 20, ["Money"], 100),
     ItemData("Poké x500", 561, ItemClassification.filler, 20, ["Money"], 500),
@@ -343,20 +434,17 @@ filler_items = [
     ItemData("Poké x5000", 563, ItemClassification.filler, 5, ["Money"], 5000),
     ItemData("Poké x200", 564, ItemClassification.filler, 20, ["Money"], 200),
     ItemData("Poké x1", 565, ItemClassification.filler, 50, ["Money"], 1),
-
     # Time to be a little nice to the players by incrementing recycle shop
     ItemData("Recycle Count +1", 571, ItemClassification.filler, 10, ["Recycles"], 1),
     ItemData("Recycle Count +5", 572, ItemClassification.filler, 10, ["Recycles"], 5),
     ItemData("Recycle Count +10", 573, ItemClassification.filler, 10, ["Recycles"], 10),
     ItemData("Recycle Count +20", 574, ItemClassification.filler, 10, ["Recycles"], 20),
-
     # General filler stuff that mostly is just flavor from the main game
     ItemData("Secret of the Waterfall", 405, ItemClassification.filler, 2, ["Generic"], 0x0),
     ItemData("Mystery of the Quicksand", 299, ItemClassification.filler, 2, ["Generic"], 0x0),
     ItemData("Chatot Repellent", 406, ItemClassification.filler, 2, ["Generic"], 0x0),
     ItemData("Sky Jukebox", 407, ItemClassification.filler, 2, ["Generic"], 0x0),
     ItemData("Recruitment Sensor", 408, ItemClassification.filler, 2, ["Generic"], 0x0),
-
     # Backpack Items
     ItemData("Rare Fossil", 410, ItemClassification.filler, 10, ["Item", "Multi"], 0xA),
     ItemData("Reviver Seed", 411, ItemClassification.filler, 5, ["Item", "Single"], 0x49),
@@ -365,14 +453,14 @@ filler_items = [
     ItemData("Apple", 414, ItemClassification.filler, 20, ["Item", "Single"], 0x6D),
     ItemData("Golden Seed", 393, ItemClassification.filler, 3, ["Item", "Single"], 0x5D),
     ItemData("Ginseng", 394, ItemClassification.filler, 1, ["Item", "Single"], 0x58),
-    #ItemData("Gold Ribbon", 395, ItemClassification.filler, 0, ["Item"], 0x20),
+    # ItemData("Gold Ribbon", 395, ItemClassification.filler, 0, ["Item"], 0x20),
     ItemData("Protein", 480, ItemClassification.filler, 10, ["Item", "Single"], 0x64),
     ItemData("Calcium", 481, ItemClassification.filler, 10, ["Item", "Single"], 0x65),
     ItemData("Iron", 482, ItemClassification.filler, 10, ["Item", "Single"], 0x66),
     ItemData("Nectar", 483, ItemClassification.filler, 10, ["Item", "Single"], 0x67),
     ItemData("Max Elixir", 484, ItemClassification.filler, 10, ["Item", "Single"], 0x63),
-    ItemData("Gabite Scale", 485, ItemClassification.filler, 10, ["Item", "Single"], 0x5c),
-    ItemData("Zinc", 486, ItemClassification.filler, 10, ["Item", "Single"], 0x6c),
+    ItemData("Gabite Scale", 485, ItemClassification.filler, 10, ["Item", "Single"], 0x5C),
+    ItemData("Zinc", 486, ItemClassification.filler, 10, ["Item", "Single"], 0x6C),
     ItemData("Sitrus Berry", 701, ItemClassification.filler, 10, ["Item", "Single"], 0x47),
     ItemData("Eyedrop Seed", 702, ItemClassification.filler, 10, ["Item", "Single"], 0x48),
     ItemData("Blinker Seed", 703, ItemClassification.filler, 10, ["Item", "Single"], 0x4A),
@@ -491,29 +579,28 @@ exclusive_filler_items = [
     ItemData("Dragon Globe", 426, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x235),  # Dragon
     ItemData("Dusk Globe", 427, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x239),  # Dark
     ItemData("Steel Globe", 428, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x23D),  # Steel
-
     # Legendary specific items
     ItemData("Freeze Veil", 429, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1D8),  # Articuno
-    #ItemData("Thunder Veil", 430, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1D9),  # Zapdos
-    #ItemData("Fire Veil", 431, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DA),  # Moltres
-    #ItemData("Havoc Robe", 432, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DB),  # Mewtwo
+    # ItemData("Thunder Veil", 430, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1D9),  # Zapdos
+    # ItemData("Fire Veil", 431, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DA),  # Moltres
+    # ItemData("Havoc Robe", 432, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DB),  # Mewtwo
     ItemData("Life Ring", 433, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DC),  # Mew
-    #ItemData("Bolt Fang", 434, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DD),  # Raikou
-    #ItemData("Flare Fang", 435, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DE),  # Entei
-    #ItemData("Aqua Mantle", 436, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DF),  # Suicune
-    #ItemData("Silver Veil", 437, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E0),  # Lugia
-    #ItemData("Rainbow Veil", 438, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E1),  # Ho-oh
+    # ItemData("Bolt Fang", 434, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DD),  # Raikou
+    # ItemData("Flare Fang", 435, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DE),  # Entei
+    # ItemData("Aqua Mantle", 436, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1DF),  # Suicune
+    # ItemData("Silver Veil", 437, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E0),  # Lugia
+    # ItemData("Rainbow Veil", 438, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E1),  # Ho-oh
     ItemData("Chrono Veil", 439, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E2),  # Celebi
     ItemData("Rock Sash", 440, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E3),  # Regirock
     ItemData("Ice Sash", 441, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E4),  # Regice
     ItemData("Steel Sash", 442, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E5),  # Registeel
-    #ItemData("Heart Brooch", 443, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E6),  # Latias
-    #ItemData("Eon Veil", 444, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E7),  # Latios
+    # ItemData("Heart Brooch", 443, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E6),  # Latias
+    # ItemData("Eon Veil", 444, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E7),  # Latios
     ItemData("Seabed Veil", 445, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E8),  # Kyogre
     ItemData("Terra Ring", 446, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1E9),  # Groudon
     ItemData("SkyHigh Veil", 447, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1EA),  # Rayquaza
-    #ItemData("Wish Mantle", 448, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1EB),  # Jirachi
-    #ItemData("Revive Robe", 449, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1EC),  # Deoxys
+    # ItemData("Wish Mantle", 448, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1EB),  # Jirachi
+    # ItemData("Revive Robe", 449, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1EC),  # Deoxys
     ItemData("Edify Robe", 450, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1EF),  # Uxie
     ItemData("Charity Robe", 451, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1F0),  # Mesprit
     ItemData("Hope Robe", 452, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1F1),  # Azelf
@@ -526,7 +613,7 @@ exclusive_filler_items = [
     ItemData("Ripple Cape", 459, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x3E5),  # Phione
     ItemData("Marine Cache", 460, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1D7),  # Phione
     ItemData("Tidal Cape", 461, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1F8),  # Manaphy
-    #ItemData("Eclipse Robe", 462, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1F9),  # Darkrai
+    # ItemData("Eclipse Robe", 462, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x1F9),  # Darkrai
     ItemData("Purify Veil", 463, ItemClassification.filler, 1, ["Item", "Exclusive"], 0x547),  # Shaymin
 ]
 
@@ -554,7 +641,6 @@ trap_items = [
     ItemData("Congealed Ruins", 71, ItemClassification.trap, 20, ["Trap", "Late", "Unique", "Dungeon"], 0x47),
     ItemData("Labyrinth Cove", 86, ItemClassification.trap, 20, ["Trap", "Early", "Unique", "Dungeon"], 0x56),
     ItemData("Dojo Ghast Maze", 190, ItemClassification.trap, 20, ["Trap", "Dojo", "Unique", "Dungeon"], 0xBE),
-
     # In dungeon traps that give a status to the player
     ItemData("Dungeon Yawn", 470, ItemClassification.trap, 20, ["Trap", "DungeonTrap"], 0x1),
     ItemData("Dungeon Whiffer", 471, ItemClassification.trap, 20, ["Trap", "DungeonTrap"], 0x2),
@@ -565,7 +651,6 @@ trap_items = [
     ItemData("Dungeon Embargo", 476, ItemClassification.trap, 20, ["Trap", "DungeonTrap"], 0x7),
     # Ooh look your next floor is a maze!
     ItemData("Dungeon Maze", 477, ItemClassification.trap, 20, ["Trap", "DungeonTrap"], 0x0),
-
 ]
 # create dictionaries and tables for later use
 filler_item_weights = [item.start_number for item in filler_items]
@@ -580,25 +665,24 @@ trap_item_table: Dict[str, ItemData] = {item.name: item for item in trap_items}
 # for items that appear multiple times, defined here
 item_frequencies: Dict[str, int] = {
     "Bag Upgrade": 5,
-    #"Hero Evolution": 1,
-    #"Recruit Evolution": 1,
+    # "Hero Evolution": 1,
+    # "Recruit Evolution": 1,
     "Recruitment": 1,
     "Formation Control": 1,
-    #"Bidoof\'s Wish": 1,
-    #"Igglybuff the Prodigy": 1,
-    #"In the Future of Darkness": 1,
-    #"Here Comes Team Charm!": 1,
-    #"Dojo Normal/Fly Maze": 1,
-    #"Dojo Dark/Fire Maze": 1,
-    #"Dojo Rock/Water Maze": 1,
-    #"Dojo Grass Maze": 1,
-    #"Dojo Elec/Steel Maze": 1,
-    #"Dojo Ice/Ground Maze": 1,
-    #"Dojo Fight/Psych Maze": 1,
-    #"Dojo Poison/Bug Maze": 1,
-    #"Dojo Dragon Maze": 1,
-    #"Dojo Ghost Maze": 1,
-
+    # "Bidoof\'s Wish": 1,
+    # "Igglybuff the Prodigy": 1,
+    # "In the Future of Darkness": 1,
+    # "Here Comes Team Charm!": 1,
+    # "Dojo Normal/Fly Maze": 1,
+    # "Dojo Dark/Fire Maze": 1,
+    # "Dojo Rock/Water Maze": 1,
+    # "Dojo Grass Maze": 1,
+    # "Dojo Elec/Steel Maze": 1,
+    # "Dojo Ice/Ground Maze": 1,
+    # "Dojo Fight/Psych Maze": 1,
+    # "Dojo Poison/Bug Maze": 1,
+    # "Dojo Dragon Maze": 1,
+    # "Dojo Ghost Maze": 1,
 }
 
 # Create a table of all the possible items in the game for AP
@@ -637,7 +721,7 @@ lootbox_table: Dict[str, Dict[str, int]] = {
         "Calm Mind": 0xBF,
         "Roar": 0xC0,
         "Toxic": 0xC1,
-        #"Hail": 0xC2,
+        # "Hail": 0xC2,
         "Bulk Up": 0xC3,
         "Bullet Seed": 0xC4,
         "Hidden Power": 0xC5,
@@ -767,7 +851,7 @@ lootbox_table: Dict[str, Dict[str, int]] = {
         "Black Gummi": 0x86,
         "Silver Gummi": 0x87,
         "Wonder Gummi": 0x88,
-        "Wander Gummi": 0xA8
+        "Wander Gummi": 0xA8,
     },
     "Glittery Box": {
         "Oran Berry": 0x46,
@@ -856,7 +940,6 @@ lootbox_table: Dict[str, Dict[str, int]] = {
         "Purple Bow": 0x1B9,
         "Violet Bow": 0x1BA,
         "Fuchsia Bow": 0x1BB,
-
     },
     "Hard Box": {
         "Key": 0xB6,
@@ -889,7 +972,6 @@ lootbox_table: Dict[str, Dict[str, int]] = {
         "Unown Rock Z": 0x1A9,
         "Unown Rock !": 0x1AA,
         "Unown Rock ?": 0x1AB,
-
     },
     "Sinister Box": {
         "Blinker Seed": 0x4A,
@@ -901,9 +983,8 @@ lootbox_table: Dict[str, Dict[str, int]] = {
         "Stun Seed": 0x5B,
         "Vile Seed": 0x5E,
         "DropEye Seed": 0x68,
-        "Grimy Food": 0x6F
+        "Grimy Food": 0x6F,
     },
-
 }
 
 # map the legendaries to their possible ids
@@ -945,5 +1026,5 @@ conditional_filler_useful_items = [
     "Hero Evolution",
     "Recruit Evolution",
     "Luminous Spring",
-    "Shaymin Village"
+    "Shaymin Village",
 ]

--- a/worlds/pmd_eos/Locations.py
+++ b/worlds/pmd_eos/Locations.py
@@ -29,12 +29,12 @@ class EOSLocation(Location):
 
 
 def get_location_table_by_groups() -> Dict[str, set[str]]:
-    #groups: Set[str] = set()
+    # groups: Set[str] = set()
     new_dict: Dict[str, set[str]] = {}
     for location_name in location_table:
         if location_table[location_name].group:
             for group in location_table[location_name].group:
-                #groups.add(group)
+                # groups.add(group)
                 if group in new_dict:
                     new_dict[group].add(location_name)
                 else:
@@ -51,8 +51,14 @@ def get_subx_table() -> List[LocationData]:
     for item in subX_table:
         if item.flag_definition == "Unused" or item.default_item == "ignore":
             continue
-        new_location = LocationData(classification=item.classification,dungeon_length=0, name=item.flag_definition,
-                                    id=subX_start_id+item.bitfield_bit_number, dungeon_start_id=0, group=["SubX"])
+        new_location = LocationData(
+            classification=item.classification,
+            dungeon_length=0,
+            name=item.flag_definition,
+            id=subX_start_id + item.bitfield_bit_number,
+            dungeon_start_id=0,
+            group=["SubX"],
+        )
         new_list.append(new_location)
 
     return new_list
@@ -84,8 +90,9 @@ def get_mission_location_table() -> typing.List[LocationData]:
                 location_id = location.id + mission_start_id + (100 * location.id) + j + 50
                 new_list.append(LocationData("Outlaw", 0, location_name, location_id, 0, []))
 
-        elif "Mission" in location.group and (location.classification == "LateDungeonComplete"
-                                              or location.classification == "BossDungeonComplete"):
+        elif "Mission" in location.group and (
+            location.classification == "LateDungeonComplete" or location.classification == "BossDungeonComplete"
+        ):
             for j in range(31):
                 location_name = f"{location.name} Mission {j + 1}"
                 location_id = location.id + mission_start_id + (100 * location.id) + j
@@ -100,12 +107,12 @@ def get_mission_location_table() -> typing.List[LocationData]:
 
 
 def get_location_table_by_start_id() -> Dict[int, set[str]]:
-    #groups: Set[str] = set()
+    # groups: Set[str] = set()
     new_dict: Dict[int, set[str]] = {}
     for location_name in location_table:
         if location_table[location_name].group:
             for group in location_table[location_name].group:
-                #groups.add(group)
+                # groups.add(group)
                 if group in new_dict:
                     new_dict[group].add(location_name)
                 else:
@@ -121,7 +128,7 @@ subx_location_dict = {location.name: location for location in subx_location_list
 
 EOS_location_table: typing.List[LocationData] = [
     # "Test Dungeon", 0,  # Should be unused
-    LocationData("EarlyDungeonComplete", 2,  "Beach Cave", 2,  1, ["Mission", "Early"]),
+    LocationData("EarlyDungeonComplete", 2, "Beach Cave", 2, 1, ["Mission", "Early"]),
     LocationData("EarlyDungeonComplete", 1, "Drenched Bluff", 3, 3, ["Mission", "Early"]),
     LocationData("EarlyDungeonComplete", 2, "Mt. Bristle", 5, 4, ["Mission", "Early"]),  # 2 subareas
     LocationData("EarlyDungeonComplete", 1, "Waterfall Cave", 6, 6, ["Mission", "Early"]),
@@ -153,14 +160,14 @@ EOS_location_table: typing.List[LocationData] = [
     LocationData("LateDungeonComplete", 1, "Surrounded Sea", 50, 50, ["Mission", "Late"]),
     LocationData("LateDungeonComplete", 3, "Miracle Sea", 52, 51, ["Mission", "Late"]),  # 3 subareas
     # LocationData("DungeonComplete", 8,  "Ice Aegis Cave", 60,  54),   # 8 subareas             we hate aegis cave. also it's kinda broken rn so we're gonna remove it for now
-    LocationData("LateDungeonComplete", 1,  "Ice Aegis Cave", 54,  54, ["Late", "Aegis", "Optional"]),
-    LocationData("LateDungeonComplete", 1,  "Regice Chamber", 55,  55, ["Late", "Aegis", "Optional"]),
-    LocationData("LateDungeonComplete", 1,  "Rock Aegis Cave", 56,  56, ["Late", "Aegis", "Optional"]),
-    LocationData("LateDungeonComplete", 1,  "Regirock Chamber", 57,  57, ["Late", "Aegis", "Optional"]),
-    LocationData("LateDungeonComplete", 1,  "Steel Aegis Cave", 58,  58, ["Late", "Aegis", "Optional"]),
-    LocationData("LateDungeonComplete", 1,  "Registeel Chamber", 59,  59, ["Late", "Aegis", "Optional"]),
-    LocationData("LateDungeonComplete", 1,  "Aegis Cave Pit", 60,  60, ["Late", "Aegis", "Optional"]),
-    LocationData("LateDungeonComplete", 1,  "Regigigas Chamber", 61,  61, ["Late", "Aegis", "Optional"]),
+    LocationData("LateDungeonComplete", 1, "Ice Aegis Cave", 54, 54, ["Late", "Aegis", "Optional"]),
+    LocationData("LateDungeonComplete", 1, "Regice Chamber", 55, 55, ["Late", "Aegis", "Optional"]),
+    LocationData("LateDungeonComplete", 1, "Rock Aegis Cave", 56, 56, ["Late", "Aegis", "Optional"]),
+    LocationData("LateDungeonComplete", 1, "Regirock Chamber", 57, 57, ["Late", "Aegis", "Optional"]),
+    LocationData("LateDungeonComplete", 1, "Steel Aegis Cave", 58, 58, ["Late", "Aegis", "Optional"]),
+    LocationData("LateDungeonComplete", 1, "Registeel Chamber", 59, 59, ["Late", "Aegis", "Optional"]),
+    LocationData("LateDungeonComplete", 1, "Aegis Cave Pit", 60, 60, ["Late", "Aegis", "Optional"]),
+    LocationData("LateDungeonComplete", 1, "Regigigas Chamber", 61, 61, ["Late", "Aegis", "Optional"]),
     LocationData("LateDungeonComplete", 1, "Mt. Travail", 62, 62, ["Mission", "Late"]),
     LocationData("LateDungeonComplete", 1, "The Nightmare", 63, 63, ["Mission", "Late"]),
     LocationData("LateDungeonComplete", 3, "Spacial Rift", 66, 64, ["Mission", "Late"]),  # 3 subareas
@@ -211,27 +218,26 @@ EOS_location_table: typing.List[LocationData] = [
     # Special Episode Dungeons
     LocationData("SpecialDungeonComplete", 3, "SE Deep Star Cave", 125, 123, ["Special"]),
     LocationData("SpecialDungeonComplete", 2, "SE Star Cave Pit", 127, 126, ["Special"]),
-    LocationData("SpecialDungeonComplete", 1,  "SE Murky Forest", 128,  128, ["Special"]),
-    LocationData("SpecialDungeonComplete", 1,  "SE Eastern Cave", 129,  129, ["Special"]),
-    LocationData("SpecialDungeonComplete", 3,  "SE Fortune Ravine", 132,  130, ["Special"]),   # 3 subareas
-    LocationData("SpecialDungeonComplete", 3,  "SE Barren Valley", 135,  133, ["Special"]),   # 3 subareas
-    LocationData("SpecialDungeonComplete", 1,  "SE Dark Wasteland", 136,  136, ["Special"]),
-    LocationData("SpecialDungeonComplete", 2,  "SE Temporal Tower", 138,  137, ["Special"]),   # 2 subareas
-    LocationData("SpecialDungeonComplete", 2,  "SE Dusk Forest", 140,  139, ["Special"]),   # 2 subareas
-    LocationData("SpecialDungeonComplete", 1,  "SE Spacial Cliffs", 141,  141, ["Special"]),
-    LocationData("SpecialDungeonComplete", 3,  "SE Dark Ice Mountain", 144,  142, ["Special"]),   # 3 subareas
-    LocationData("SpecialDungeonComplete", 1,  "SE Icicle Forest", 145,  145, ["Special"]),
-    LocationData("SpecialDungeonComplete", 3,  "SE Vast Ice Mountain", 148,  146, ["Special"]),   # 3 subareas
-    LocationData("SpecialDungeonComplete", 1,  "SE Southern Jungle", 149,  149, ["Special"]),
-    LocationData("SpecialDungeonComplete", 3,  "SE Boulder Quarry", 152,  150, ["Special"]),   # 3 subareas
-    LocationData("SpecialDungeonComplete", 1,  "SE Right Cave Path", 153,  153, ["Special"]),
-    LocationData("SpecialDungeonComplete", 1,  "SE Left Cave Path", 154,  154, ["Special"]),
-    LocationData("SpecialDungeonComplete", 3,  "SE Limestone Cavern", 157,  155, ["Special"]),   # 3 subareas
-    LocationData("SpecialDungeonComplete", 2,  "SE Upper Spring Cave", 159,  158, ["Special"]),   # 7 subareas
+    LocationData("SpecialDungeonComplete", 1, "SE Murky Forest", 128, 128, ["Special"]),
+    LocationData("SpecialDungeonComplete", 1, "SE Eastern Cave", 129, 129, ["Special"]),
+    LocationData("SpecialDungeonComplete", 3, "SE Fortune Ravine", 132, 130, ["Special"]),  # 3 subareas
+    LocationData("SpecialDungeonComplete", 3, "SE Barren Valley", 135, 133, ["Special"]),  # 3 subareas
+    LocationData("SpecialDungeonComplete", 1, "SE Dark Wasteland", 136, 136, ["Special"]),
+    LocationData("SpecialDungeonComplete", 2, "SE Temporal Tower", 138, 137, ["Special"]),  # 2 subareas
+    LocationData("SpecialDungeonComplete", 2, "SE Dusk Forest", 140, 139, ["Special"]),  # 2 subareas
+    LocationData("SpecialDungeonComplete", 1, "SE Spacial Cliffs", 141, 141, ["Special"]),
+    LocationData("SpecialDungeonComplete", 3, "SE Dark Ice Mountain", 144, 142, ["Special"]),  # 3 subareas
+    LocationData("SpecialDungeonComplete", 1, "SE Icicle Forest", 145, 145, ["Special"]),
+    LocationData("SpecialDungeonComplete", 3, "SE Vast Ice Mountain", 148, 146, ["Special"]),  # 3 subareas
+    LocationData("SpecialDungeonComplete", 1, "SE Southern Jungle", 149, 149, ["Special"]),
+    LocationData("SpecialDungeonComplete", 3, "SE Boulder Quarry", 152, 150, ["Special"]),  # 3 subareas
+    LocationData("SpecialDungeonComplete", 1, "SE Right Cave Path", 153, 153, ["Special"]),
+    LocationData("SpecialDungeonComplete", 1, "SE Left Cave Path", 154, 154, ["Special"]),
+    LocationData("SpecialDungeonComplete", 3, "SE Limestone Cavern", 157, 155, ["Special"]),  # 3 subareas
+    LocationData("SpecialDungeonComplete", 2, "SE Upper Spring Cave", 159, 158, ["Special"]),  # 7 subareas
     LocationData("SpecialDungeonComplete", 2, "SE Middle Spring Cave", 161, 160, ["Special"]),  # 7 subareas
     LocationData("SpecialDungeonComplete", 3, "SE Spring Cave Pit", 164, 162, ["Special"]),  # 7 subareas
-
-    LocationData("EarlyDungeonComplete", 1, "Star Cave", 174,  174, ["Mission", "Early"]),
+    LocationData("EarlyDungeonComplete", 1, "Star Cave", 174, 174, ["Mission", "Early"]),
     # Dojo Dungeons
     LocationData("DojoDungeonComplete", 1, "Dojo Normal/Fly Maze", 180, 180, ["Dojo"]),  # 7 subareas
     LocationData("DojoDungeonComplete", 1, "Dojo Dark/Fire Maze", 181, 181, ["Dojo"]),  # 7 subareas
@@ -284,63 +290,57 @@ EOS_location_table: typing.List[LocationData] = [
     LocationData("SpindaDrink", 0, "Spinda Drink 18", 937, 0, ["SpindaDrink"]),
     LocationData("SpindaDrink", 0, "Spinda Drink 19", 938, 0, ["SpindaDrink"]),
     LocationData("SpindaDrink", 0, "Spinda Drink 20", 939, 0, ["SpindaDrink"]),
-    LocationData("Event", 0,  "Final Boss", 999, 0),
-
+    LocationData("Event", 0, "Final Boss", 999, 0),
     # generic checks, right now just bag upgrades
-    #LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 1", 300, 0),
-    #LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 2", 301, 0),
-    #LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 3", 302, 0),
-    #LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 4", 303, 0),
-    #LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 5", 304, 0),
-
-    #LocationData("SEDungeonUnlock", 0, "Bidoof's Wish Location", 305, 0),
-    #LocationData("SEDungeonUnlock", 0, "Igglybuff the Prodigy Location", 306, 0),
-    #LocationData("SEDungeonUnlock", 0, 'Today\'s "Oh My Gosh" Location', 307, 0),
-    #LocationData("SEDungeonUnlock", 0, "Here Comes Team Charm! Location", 308, 0),
-    #LocationData("SEDungeonUnlock", 0, "In the Future of Darkness Location", 309, 0),
-
-    #LocationData("ShopItem", 0, "Shop Item 1", 310, 0),
-    #LocationData("ShopItem", 0, "Shop Item 2", 311, 0),
-    #LocationData("ShopItem", 0, "Shop Item 3", 312, 0),
-    #LocationData("ShopItem", 0, "Shop Item 4", 313, 0),
-    #LocationData("ShopItem", 0, "Shop Item 5", 314, 0),
-    #LocationData("ShopItem", 0, "Shop Item 6", 315, 0),
-    #LocationData("ShopItem", 0, "Shop Item 7", 316, 0),
-    #LocationData("ShopItem", 0, "Shop Item 8", 317, 0),
-    #LocationData("ShopItem", 0, "Shop Item 9", 318, 0),
-    #LocationData("ShopItem", 0, "Shop Item 10", 319, 0),
-    #LocationData("SEDungeonUnlock", 0, "Team Name", 427, 0),
-    #LocationData("Manaphy", 0, "Manaphy Egg Hatch", 320, 0),
-    #LocationData("Manaphy", 0, "Manaphy Fed", 321, 0),
-    #LocationData("Manaphy", 0, "Manaphy Healed", 322, 0),
-    #LocationData("Manaphy", 0, "Manaphy Join Team", 323, 0),
-    #LocationData("Manaphy", 0, "Manaphy Leads To Marine Resort", 324, 0),
-    #LocationData("SecretRank", 0, "SecretRank", 347, 0),
-
-    #LocationData("Legendary", 0, "Recruit Uxie", 325, 0),
-    #LocationData("Legendary", 0, "Recruit Mesprit", 326, 0),
-    #LocationData("Legendary", 0, "Recruit Azelf", 327, 0),
-    #LocationData("Legendary", 0, "Recruit Dialga", 328, 0),
-    #LocationData("Legendary", 0, "Recruit Phione", 329, 0),
-    #LocationData("Legendary", 0, "Recruit Palkia", 330, 0),
-    #LocationData("Legendary", 0, "Recruit Kyogre", 332, 0),
-    #LocationData("Legendary", 0, "Recruit Groudon", 334, 0),
-    #LocationData("Legendary", 0, "Recruit Articuno", 336, 0),
-    #LocationData("Legendary", 0, "Recruit Heatran", 338, 0),
-    #LocationData("Legendary", 0, "Recruit Giratina", 340, 0),
-    #LocationData("Legendary", 0, "Recruit Rayquaza", 342, 0),
-    #LocationData("Legendary", 0, "Recruit Mew", 344, 0),
-    #LocationData("Legendary", 0, "Recruit Cresselia", 345, 0),
-    #LocationData("Legendary", 0, "Recruit Shaymin", 346, 0),
-
-    #LocationData("Instrument", 0, "Get Aqua-Monica", 331, 0),
-    #LocationData("Instrument", 0, "Get Terra Cymbal", 333, 0),
-    #LocationData("Instrument", 0, "Get Icy Flute", 335, 0),
-    #LocationData("Instrument", 0, "Get Fiery Drum", 337, 0),
-    #LocationData("Instrument", 0, "Get Rock Horn", 339, 0),
-    #LocationData("Instrument", 0, "Get Sky Melodica", 341, 0),
-    #LocationData("Instrument", 0, "Get Grass Cornet", 343, 0),
-
+    # LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 1", 300, 0),
+    # LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 2", 301, 0),
+    # LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 3", 302, 0),
+    # LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 4", 303, 0),
+    # LocationData("ProgressiveBagUpgrade", 0, "Progressive Bag loc 5", 304, 0),
+    # LocationData("SEDungeonUnlock", 0, "Bidoof's Wish Location", 305, 0),
+    # LocationData("SEDungeonUnlock", 0, "Igglybuff the Prodigy Location", 306, 0),
+    # LocationData("SEDungeonUnlock", 0, 'Today\'s "Oh My Gosh" Location', 307, 0),
+    # LocationData("SEDungeonUnlock", 0, "Here Comes Team Charm! Location", 308, 0),
+    # LocationData("SEDungeonUnlock", 0, "In the Future of Darkness Location", 309, 0),
+    # LocationData("ShopItem", 0, "Shop Item 1", 310, 0),
+    # LocationData("ShopItem", 0, "Shop Item 2", 311, 0),
+    # LocationData("ShopItem", 0, "Shop Item 3", 312, 0),
+    # LocationData("ShopItem", 0, "Shop Item 4", 313, 0),
+    # LocationData("ShopItem", 0, "Shop Item 5", 314, 0),
+    # LocationData("ShopItem", 0, "Shop Item 6", 315, 0),
+    # LocationData("ShopItem", 0, "Shop Item 7", 316, 0),
+    # LocationData("ShopItem", 0, "Shop Item 8", 317, 0),
+    # LocationData("ShopItem", 0, "Shop Item 9", 318, 0),
+    # LocationData("ShopItem", 0, "Shop Item 10", 319, 0),
+    # LocationData("SEDungeonUnlock", 0, "Team Name", 427, 0),
+    # LocationData("Manaphy", 0, "Manaphy Egg Hatch", 320, 0),
+    # LocationData("Manaphy", 0, "Manaphy Fed", 321, 0),
+    # LocationData("Manaphy", 0, "Manaphy Healed", 322, 0),
+    # LocationData("Manaphy", 0, "Manaphy Join Team", 323, 0),
+    # LocationData("Manaphy", 0, "Manaphy Leads To Marine Resort", 324, 0),
+    # LocationData("SecretRank", 0, "SecretRank", 347, 0),
+    # LocationData("Legendary", 0, "Recruit Uxie", 325, 0),
+    # LocationData("Legendary", 0, "Recruit Mesprit", 326, 0),
+    # LocationData("Legendary", 0, "Recruit Azelf", 327, 0),
+    # LocationData("Legendary", 0, "Recruit Dialga", 328, 0),
+    # LocationData("Legendary", 0, "Recruit Phione", 329, 0),
+    # LocationData("Legendary", 0, "Recruit Palkia", 330, 0),
+    # LocationData("Legendary", 0, "Recruit Kyogre", 332, 0),
+    # LocationData("Legendary", 0, "Recruit Groudon", 334, 0),
+    # LocationData("Legendary", 0, "Recruit Articuno", 336, 0),
+    # LocationData("Legendary", 0, "Recruit Heatran", 338, 0),
+    # LocationData("Legendary", 0, "Recruit Giratina", 340, 0),
+    # LocationData("Legendary", 0, "Recruit Rayquaza", 342, 0),
+    # LocationData("Legendary", 0, "Recruit Mew", 344, 0),
+    # LocationData("Legendary", 0, "Recruit Cresselia", 345, 0),
+    # LocationData("Legendary", 0, "Recruit Shaymin", 346, 0),
+    # LocationData("Instrument", 0, "Get Aqua-Monica", 331, 0),
+    # LocationData("Instrument", 0, "Get Terra Cymbal", 333, 0),
+    # LocationData("Instrument", 0, "Get Icy Flute", 335, 0),
+    # LocationData("Instrument", 0, "Get Fiery Drum", 337, 0),
+    # LocationData("Instrument", 0, "Get Rock Horn", 339, 0),
+    # LocationData("Instrument", 0, "Get Sky Melodica", 341, 0),
+    # LocationData("Instrument", 0, "Get Grass Cornet", 343, 0),
 ] + subx_location_list
 
 
@@ -351,11 +351,13 @@ location_table.update(subx_location_dict)
 
 location_table_by_groups = get_location_table_by_groups()
 
-location_dict_by_start_id: typing.Dict[int, LocationData] = {location.dungeon_start_id: location for location in EOS_location_table}
+location_dict_by_start_id: typing.Dict[int, LocationData] = {
+    location.dungeon_start_id: location for location in EOS_location_table
+}
 
 mission_location_table = get_mission_location_table()
 
 expanded_EOS_location_table: typing.List[LocationData] = []
 expanded_EOS_location_table.extend(EOS_location_table)
-#expanded_EOS_location_table.extend(subx_location_list)
+# expanded_EOS_location_table.extend(subx_location_list)
 expanded_EOS_location_table.extend(mission_location_table)

--- a/worlds/pmd_eos/Options.py
+++ b/worlds/pmd_eos/Options.py
@@ -1,7 +1,16 @@
 import typing
 from dataclasses import dataclass
-from Options import DefaultOnToggle, Toggle, Choice, PerGameCommonOptions, StartInventoryPool, NamedRange, Range, \
-    DeathLink, OptionSet
+from Options import (
+    DefaultOnToggle,
+    Toggle,
+    Choice,
+    PerGameCommonOptions,
+    StartInventoryPool,
+    NamedRange,
+    Range,
+    DeathLink,
+    OptionSet,
+)
 
 
 class Goal(Choice):
@@ -9,6 +18,7 @@ class Goal(Choice):
     Dialga - Get X relic fragment shards to unlock hidden land. Find Temporal Tower location
             then go through hidden land via Lapras on the beach to beat dialga
     Darkrai - Beat Dialga (all the same requirements), then get X instruments to unlock Dark Crater"""
+
     display_name = "Goal"
     option_dialga = 0
     option_darkrai = 1
@@ -16,144 +26,104 @@ class Goal(Choice):
 
 
 class FragmentShards(NamedRange):
-    """ How many Relic Fragment Shards should be required in the game (Macguffins)
-     that you must get to unlock Hidden Land"""
+    """How many Relic Fragment Shards should be required in the game (Macguffins)
+    that you must get to unlock Hidden Land"""
+
     range_start = 4
     range_end = 15
-    special_range_names = {
-        "easy": 4,
-        "normal": 6,
-        "hard": 8,
-        "extreme": 10
-    }
+    special_range_names = {"easy": 4, "normal": 6, "hard": 8, "extreme": 10}
     default = 6
 
 
 class ExtraShards(NamedRange):
-    """ How many total Fragment Shards should be in the game?
+    """How many total Fragment Shards should be in the game?
     If the total shards is less than required shards, the total shard amount is equal to the required shard amount"""
+
     range_start = 0
     range_end = 20
-    special_range_names = {
-        "easy": 16,
-        "normal": 12,
-        "hard": 8,
-        "extreme": 0
-    }
+    special_range_names = {"easy": 16, "normal": 12, "hard": 8, "extreme": 0}
     default = 12
 
 
 class RequiredInstruments(NamedRange):
-    """ How many Instruments should be required in the game (Macguffins)
-     that you must get to unlock Dark Crater if victory condition is Darkrai
-     Instruments are not added to the item pool if the goal is Dialga"""
+    """How many Instruments should be required in the game (Macguffins)
+    that you must get to unlock Dark Crater if victory condition is Darkrai
+    Instruments are not added to the item pool if the goal is Dialga"""
+
     range_start = 4
     range_end = 15
-    special_range_names = {
-        "easy": 4,
-        "normal": 6,
-        "hard": 8,
-        "extreme": 10
-    }
+    special_range_names = {"easy": 4, "normal": 6, "hard": 8, "extreme": 10}
     default = 6
 
 
 class ExtraInstruments(NamedRange):
-    """ How many total Instruments should be in the game?
+    """How many total Instruments should be in the game?
     If the total instruments is less than required instruments,
      the total instrument amount is equal to the required instrument amount"""
+
     range_start = 0
     range_end = 20
-    special_range_names = {
-        "easy": 16,
-        "normal": 12,
-        "hard": 8,
-        "extreme": 0
-    }
+    special_range_names = {"easy": 16, "normal": 12, "hard": 8, "extreme": 0}
     default = 12
 
 
 class EarlyMissionChecks(NamedRange):
-    """ How many Missions per dungeon pre dialga should be checks?
-        0 equals missions are not checks"""
+    """How many Missions per dungeon pre dialga should be checks?
+    0 equals missions are not checks"""
+
     range_start = 0
     range_end = 31
-    special_range_names = {
-        "off": 0,
-        "some": 4,
-        "lots": 10,
-        "insanity": 31
-    }
+    special_range_names = {"off": 0, "some": 4, "lots": 10, "insanity": 31}
     default = 4
 
 
 class LateMissionChecks(NamedRange):
-    """ How many Missions per dungeon post-dialga (including Hidden Land
+    """How many Missions per dungeon post-dialga (including Hidden Land
     and Temporal Tower) should be checks? 0 equals missions are not checks"""
+
     range_start = 0
     range_end = 31
-    special_range_names = {
-        "off": 0,
-        "some": 4,
-        "lots": 10,
-        "insanity": 31
-    }
+    special_range_names = {"off": 0, "some": 4, "lots": 10, "insanity": 31}
     default = 4
 
 
 class EarlyOutlawChecks(NamedRange):
-    """ How many outlaws per dungeon pre dialga should be checks?
-        0 equals outlaws are not checks"""
+    """How many outlaws per dungeon pre dialga should be checks?
+    0 equals outlaws are not checks"""
+
     range_start = 0
     range_end = 31
-    special_range_names = {
-        "off": 0,
-        "some": 2,
-        "lots": 10,
-        "insanity": 31
-    }
+    special_range_names = {"off": 0, "some": 2, "lots": 10, "insanity": 31}
     default = 2
 
 
 class LateOutlawChecks(NamedRange):
-    """ How many Missions per dungeon post-dialga (including Hidden Land
+    """How many Missions per dungeon post-dialga (including Hidden Land
     and Temporal Tower) should be checks? 0 equals outlaws are not checks"""
+
     range_start = 0
     range_end = 31
-    special_range_names = {
-        "off": 0,
-        "some": 2,
-        "lots": 10,
-        "insanity": 31
-    }
+    special_range_names = {"off": 0, "some": 2, "lots": 10, "insanity": 31}
     default = 2
 
 
 class SpindaDrinkEvents(NamedRange):
     """How many drink events should be checks?"""
+
     default_name = "Spinda Drink Events"
     range_start = 0
     range_end = 20
-    special_range_names = {
-        "few": 5,
-        "some": 10,
-        "lots": 15,
-        "all": 20
-    }
+    special_range_names = {"few": 5, "some": 10, "lots": 15, "all": 20}
     default = 5
 
 
 class SpindaBasicDrinks(NamedRange):
     """How many Spinda Drinks should be checks?"""
+
     display_name = "Spinda Drinks"
     range_start = 0
     range_end = 20
-    special_range_names = {
-        "few": 5,
-        "some": 10,
-        "lots": 15,
-        "all": 20
-    }
+    special_range_names = {"few": 5, "some": 10, "lots": 15, "all": 20}
     default = 5
 
 
@@ -167,12 +137,14 @@ class StartWithBag(DefaultOnToggle):
 class Recruitment(DefaultOnToggle):
     """Start with recruitment enabled?
     If false, recruitment will be an item available in game"""
+
     display_name = "Recruitment Enable"
 
 
 class RecruitmentEvolution(DefaultOnToggle):
     """Start with Recruitment Evolution Enabled?
     If false, evolution will be an item available in game"""
+
     display_name = "Recruitment Evolution Enable"
 
 
@@ -181,13 +153,15 @@ class HeroEvolution(DefaultOnToggle):
     If false, hero evolution will be an item available in game.
     Note: hero evolution does nothing until recruitment
     evolution has been unlocked"""
+
     display_name = "Partner/Hero Evolution Enable"
 
 
 class FullTeamFormationControl(DefaultOnToggle):
-    """ Start with full team formation control?
+    """Start with full team formation control?
     If false, full team formation control will be an item
     available in game"""
+
     display_name = "Formation Control Enable"
 
 
@@ -199,6 +173,7 @@ class LevelScaling(Choice):
     Easy: Enemies will be bumped down to the highest party level if they're above it.
     Difficult: Enemies will be bumped either down or up to match the party level regardless of their vanilla level
     Regardless of your choice, bosses at the end of dungeons will NOT scale."""
+
     display_name = "Level Scaling"
     option_off = 0
     option_easy = 1
@@ -208,7 +183,8 @@ class LevelScaling(Choice):
 
 class GuestScaling(DefaultOnToggle):
     """Makes the dungeon guests (Bidoof in Cragy Coast, Grovyle in Hidden Land, etc.) scale to your party level
-        Does nothing if Level scaling is off"""
+    Does nothing if Level scaling is off"""
+
     display_name = "Guest Scaling"
 
 
@@ -221,6 +197,7 @@ class StarterOption(Choice):
     Choose: Skip the quiz and go straight to choosing your starter and partner
     For both Choose and Override you will be able to pick partner exclusive pokemon for your starter as well as gender
     exclusive pokemon regardless of gender"""
+
     display_name = "Starter Choice Option"
     option_vanilla = 0
     option_random_starter = 1
@@ -230,23 +207,26 @@ class StarterOption(Choice):
 
 
 class TypeSanity(Toggle):
-    """ Allow for your partner to share a type with your main character
+    """Allow for your partner to share a type with your main character
     WARNING: The game is not balanced around this, and we have not done anything to change that.
     Use at your own risk
     """
+
     display_name = "Type Sanity"
 
 
 class SpecialEpisodeSanity(Toggle):
-    """ Start the game with one of the special episodes and NOT the main game.
+    """Start the game with one of the special episodes and NOT the main game.
     Unlock the main game through an item
     Overridden by Excluding Special Episodes"""
+
     display_name = "Special Episode Sanity"
 
 
 class ExcludeSpecialEpisodes(Toggle):
-    """ No special episode items will be added to the game
+    """No special episode items will be added to the game
     Overrides Special Episode Sanity"""
+
     display_name = "Exclude Special Episodes"
 
 
@@ -277,6 +257,7 @@ class SkyPeakType(Choice):
     1: Progressive (unlock dungeons sequentially when you pick up a sky peak item)
     2. All Random (unlock sky peak dungeons completely at random based on which sky peak item you pick up)
     3: All unlocked from one item (there will be one sky peak item that unlocks all sky peak checks)"""
+
     display_name = "Sky Peak Type"
     option_progressive = 1
     option_all_random = 2
@@ -286,6 +267,7 @@ class SkyPeakType(Choice):
 
 class DojoDungeons(NamedRange):
     """How many dojo dungeons should be accessible at start?"""
+
     display_name = "Dojo Dungeons Randomized"
     range_start = 0
     range_end = 10
@@ -300,9 +282,9 @@ class DojoDungeons(NamedRange):
 
 class LegendariesInPool(Range):
     """How many Legendary Pokemon should be in the item pool for you to recruit?
-        The Legendary will only come post-dialga if you get it early
-        Legendaries are disabled if you are going for a dialga goal
-        """
+    The Legendary will only come post-dialga if you get it early
+    Legendaries are disabled if you are going for a dialga goal
+    """
 
     display_name = "Legendaries in Item Pool"
     range_start = 0
@@ -311,9 +293,10 @@ class LegendariesInPool(Range):
 
 
 class AllowedLegendaries(OptionSet):
-    """ Set which Legendaries will be available for the item pool as recruits.
+    """Set which Legendaries will be available for the item pool as recruits.
     NOTE: legendaries normally found in dungeons are not yet randomized. This only includes legendary recruits at the ends of dungeons
     """
+
     display_name = "Allowed Legendary Recruits"
     valid_keys = [
         "Regirock",
@@ -355,6 +338,7 @@ class AllowTraps(Choice):
     1: regular traps allowed, nothing too crazy
     2: mean traps allowed (possibility of getting two traps at the same time *unown sentry duty*)
     MEAN TRAPS NOT CURRENTLY IMPLEMENTED CURRENTLY 1 AND 2 DO THE SAME THING WHICH IS JUST ENABLE TRAPS"""
+
     display_name = "Allow Traps"
     option_disabled = 0
     option_regular = 1
@@ -365,11 +349,13 @@ class InvisibleTraps(Toggle):
     """Make all traps invisible so when they come in from the client you don't know what happens until you get the trap
     activated
     NOT YET IMPLEMENTED"""
+
     display_name = "Invisible Traps"
 
 
 class TrapPercentage(Range):
     """What percentage of filler items should be traps? Range from 0 to 100 (affected by allowed traps)"""
+
     display_name = "Trap Percentage"
     range_start = 0
     range_end = 100
@@ -378,29 +364,34 @@ class TrapPercentage(Range):
 
 class CursedAegisCave(Toggle):
     """Do you want Aegis cave to logically require you to beat a regi you don't have a seal for?"""
+
     display_name = "Cursed Aegis Cave"
 
 
 class LongLocationsInclusion(Toggle):
     """Include Rule dungeons, clearing all dojos, final dojo, ludicolo dance,
     and duskull bank checks over 20k in logic"""
+
     display_name = "Long Locations"
 
 
 class EarlyMissionFloors(DefaultOnToggle):
     """Allow missions to start on floor 2 of dungeons instead on (floors/2)"""
+
     display_name = "Mission on Early Floors"
 
 
 class MoveShortcutMenu(DefaultOnToggle):
     """Enable the Move Shortcut Menu by holding (default L button)
     Disabling this current is not implemented ROMSide"""
+
     display_name = "Move Shortcut Menu"
 
 
 class MaxRequiredRank(Choice):
     """What is the maximum required rank you want to be logically necessary
     If your goal is dialga and your max rank is above master rank, your max will be set to master rank"""
+
     display_name = "Max Required Rank"
     option_disabled = 0
     option_bronze = 1

--- a/worlds/pmd_eos/Rom.py
+++ b/worlds/pmd_eos/Rom.py
@@ -36,8 +36,13 @@ class EOSProcedurePatch(APProcedurePatch, APTokenMixin):
         return get_base_rom_as_bytes()
 
 
-def write_tokens(world: "EOSWorld", patch: EOSProcedurePatch, hint_items: list[Location],
-                 dimensional_screams: list[Location], starting_se: int) -> None:
+def write_tokens(
+    world: "EOSWorld",
+    patch: EOSProcedurePatch,
+    hint_items: list[Location],
+    dimensional_screams: list[Location],
+    starting_se: int,
+) -> None:
     ov36_mem_loc = 2724352  # find_ov36_mem_location()
     seed_offset = 0x36FA0
     player_name_offset = 0x36F80
@@ -52,9 +57,9 @@ def write_tokens(world: "EOSWorld", patch: EOSProcedurePatch, hint_items: list[L
     dimensional_scream_who_offset = hintable_items_offset + 0x4
     dimensional_scream_what_offset = hintable_items_offset + 0x202
     dimensional_scream_where_offset = hintable_items_offset + 0x5E0
-    #dimensional_scream_hints = get_dimensional_hints(world)
+    # dimensional_scream_hints = get_dimensional_hints(world)
     dimensional_scream_hints = dimensional_screams
-    #writable_screams = [k.address for k in dimensional_scream_hints]
+    # writable_screams = [k.address for k in dimensional_scream_hints]
     # recruitment_offset = 0x3702C
     # recruitment_evo_offset = 0x37030
     # team_formation_offset = 0x37034
@@ -104,10 +109,8 @@ def write_tokens(world: "EOSWorld", patch: EOSProcedurePatch, hint_items: list[L
     player_name_changed_encoded = player_name_changed.encode("cp1252", "xmlcharrefreplace")
 
     # Bake player name into ROM
-    patch.write_token(APTokenTypes.WRITE, ov36_mem_loc+player_name_changed_offset,
-                      player_name_changed_encoded)
-    patch.write_token(APTokenTypes.WRITE, ov36_mem_loc + player_name_offset,
-                      player_name_encoded)
+    patch.write_token(APTokenTypes.WRITE, ov36_mem_loc + player_name_changed_offset, player_name_changed_encoded)
+    patch.write_token(APTokenTypes.WRITE, ov36_mem_loc + player_name_offset, player_name_encoded)
 
     # Bake names of previewable items into ROM
     for i in range(len(hint_items)):
@@ -118,23 +121,34 @@ def write_tokens(world: "EOSWorld", patch: EOSProcedurePatch, hint_items: list[L
         else:
             hint_loc_name = hint_items[i].name.translate(trans_table)
         hint_player = world.multiworld.player_name[hint_items[i].item.player].translate(trans_table)
-        patch.write_token(APTokenTypes.WRITE, dimensional_scream_who_offset + 17 * i,
-                          hint_player[0:15].encode("cp1252", "xmlcharrefreplace"))
+        patch.write_token(
+            APTokenTypes.WRITE,
+            dimensional_scream_who_offset + 17 * i,
+            hint_player[0:15].encode("cp1252", "xmlcharrefreplace"),
+        )
 
-        patch.write_token(APTokenTypes.WRITE, dimensional_scream_where_offset + 33 * i,
-                          hint_loc_name[0:31].encode("cp1252", "xmlcharrefreplace"))
+        patch.write_token(
+            APTokenTypes.WRITE,
+            dimensional_scream_where_offset + 33 * i,
+            hint_loc_name[0:31].encode("cp1252", "xmlcharrefreplace"),
+        )
 
         hint_item = hint_items[i].item.name.translate(trans_table)
-        patch.write_token(APTokenTypes.WRITE, dimensional_scream_what_offset + 33 * i,
-                          hint_item[0:31].encode("cp1252", "xmlcharrefreplace"))
-
+        patch.write_token(
+            APTokenTypes.WRITE,
+            dimensional_scream_what_offset + 33 * i,
+            hint_item[0:31].encode("cp1252", "xmlcharrefreplace"),
+        )
 
     # Bake the dimensional Scream Hints into the ROM
 
     for i in range(len(dimensional_scream_hints)):
         hint_player = world.multiworld.player_name[dimensional_scream_hints[i].player].translate(trans_table)
-        patch.write_token(APTokenTypes.WRITE, dimensional_scream_who_offset + 17 * (i + 10),
-                          hint_player[0:15].encode("cp1252", "xmlcharrefreplace"))
+        patch.write_token(
+            APTokenTypes.WRITE,
+            dimensional_scream_who_offset + 17 * (i + 10),
+            hint_player[0:15].encode("cp1252", "xmlcharrefreplace"),
+        )
         if dimensional_scream_hints[i].name.__contains__("★"):
             hint_loc_name1 = dimensional_scream_hints[i].name.translate(trans_table)
             hint_loc_name = hint_loc_name1.replace("★", "[M:S3]")
@@ -142,15 +156,21 @@ def write_tokens(world: "EOSWorld", patch: EOSProcedurePatch, hint_items: list[L
         else:
             hint_loc_name = dimensional_scream_hints[i].name.translate(trans_table)
         # hint_loc_name = dimensional_scream_hints[i].name.translate(trans_table)
-        patch.write_token(APTokenTypes.WRITE, dimensional_scream_where_offset + 33 * (i + 10),
-                          hint_loc_name[0:31].encode("cp1252", "xmlcharrefreplace"))
+        patch.write_token(
+            APTokenTypes.WRITE,
+            dimensional_scream_where_offset + 33 * (i + 10),
+            hint_loc_name[0:31].encode("cp1252", "xmlcharrefreplace"),
+        )
 
         hint_item = dimensional_scream_hints[i].item.name.translate(trans_table)
-        patch.write_token(APTokenTypes.WRITE, dimensional_scream_what_offset + 33 * (i + 10),
-                          hint_item[0:31].encode("cp1252", "xmlcharrefreplace"))
+        patch.write_token(
+            APTokenTypes.WRITE,
+            dimensional_scream_what_offset + 33 * (i + 10),
+            hint_item[0:31].encode("cp1252", "xmlcharrefreplace"),
+        )
 
     # Bake seed name into ROM
-    patch.write_token(APTokenTypes.WRITE, ov36_mem_loc+seed_offset, seed)
+    patch.write_token(APTokenTypes.WRITE, ov36_mem_loc + seed_offset, seed)
 
     write_byte = 0
     late_missions_count = 0
@@ -218,13 +238,13 @@ def write_tokens(world: "EOSWorld", patch: EOSProcedurePatch, hint_items: list[L
     if world.options.special_episode_sanity.value == 1 and starting_se != 0:
         write_byte = write_byte | (starting_se << 32)
 
-
     # write the tokens that will be applied and write the token data into the bin for AP
-    patch.write_token(APTokenTypes.WRITE, ov36_mem_loc + ap_settings_offset,
-                      int.to_bytes(write_byte, length=9, byteorder="little"))
+    patch.write_token(
+        APTokenTypes.WRITE, ov36_mem_loc + ap_settings_offset, int.to_bytes(write_byte, length=9, byteorder="little")
+    )
 
     patch.write_file("token_data.bin", patch.get_token_binary())
-    #testnum = find_ov36_mem_location()
+    # testnum = find_ov36_mem_location()
 
 
 def find_ov36_mem_location() -> int:
@@ -234,11 +254,9 @@ def find_ov36_mem_location() -> int:
     test = range(0x296000, 0x300000)
     for byte_i in range(0x297000, 0x300000):
         # , byte in enumerate(rom)
-        intest= 0x297000 / 2
+        intest = 0x297000 / 2
         hex_search_value = 0xBAADF00D
-        hex_searched = int.from_bytes((rom[byte_i:(byte_i+4)]))
-        test2 = rom[byte_i:(byte_i+4)]
+        hex_searched = int.from_bytes((rom[byte_i : (byte_i + 4)]))
+        test2 = rom[byte_i : (byte_i + 4)]
         if hex_searched == hex_search_value:
             return byte_i
-
-

--- a/worlds/pmd_eos/RomTypeDefinitions.py
+++ b/worlds/pmd_eos/RomTypeDefinitions.py
@@ -1,7 +1,7 @@
 from typing import List, NamedTuple
 
 
-class SubXBitfield (NamedTuple):
+class SubXBitfield(NamedTuple):
     bitfield_bit_number: int
     subX_area: int
     subX_byte: int
@@ -17,13 +17,16 @@ subX_table = [
     SubXBitfield(1, 1, 0, 1, "Bag Upgrade 2", ["Mt. Bristle"], "Bag Upgrade", "ProgressiveBagUpgrade"),
     SubXBitfield(2, 1, 0, 2, "Bag Upgrade 3", ["Apple Woods"], "Bag Upgrade", "ProgressiveBagUpgrade"),
     SubXBitfield(3, 1, 0, 3, "Bag Upgrade 4", ["Steam Cave"], "Bag Upgrade", "ProgressiveBagUpgrade"),
-    SubXBitfield(4, 1, 0, 4, "Bag Upgrade 5", ["Defeat Dialga", "Mystifying Forest"], "Bag Upgrade", "ProgressiveBagUpgrade"),
+    SubXBitfield(
+        4, 1, 0, 4, "Bag Upgrade 5", ["Defeat Dialga", "Mystifying Forest"], "Bag Upgrade", "ProgressiveBagUpgrade"
+    ),
     SubXBitfield(5, 1, 0, 5, "Bidoof's Wish Location", [], "Bidoof's SE", "Free"),
     SubXBitfield(6, 1, 0, 6, "Igglybuff the Prodigy Location", [], "Igglybuff's SE", "Free"),
     SubXBitfield(7, 1, 0, 7, 'Today\'s "Oh My Gosh" Location', [], "Sunflora's SE", "Free"),
     SubXBitfield(8, 1, 1, 0, "Here Comes Team Charm! Location", [], "Team Charm SE", "Free"),
-    SubXBitfield(9, 1, 1, 1, "In the Future of Darkness Location", ["Hidden Land"], "Grovyle + Dusknoir SE",
-                 "SEDungeonUnlock"),
+    SubXBitfield(
+        9, 1, 1, 1, "In the Future of Darkness Location", ["Hidden Land"], "Grovyle + Dusknoir SE", "SEDungeonUnlock"
+    ),
     SubXBitfield(10, 1, 1, 2, "Shop Item 1", ["ProgressiveBag3", "Main Game"], "Filler", "ShopItem"),  # 5k
     SubXBitfield(11, 1, 1, 3, "Shop Item 2", ["ProgressiveBag2", "Main Game"], "Filler", "ShopItem"),  # 1k
     SubXBitfield(12, 1, 1, 4, "Shop Item 3", ["ProgressiveBag2", "Main Game"], "Filler", "ShopItem"),  # 1k
@@ -36,46 +39,98 @@ subX_table = [
     SubXBitfield(19, 2, 0, 3, "Shop Item 10", [], "Filler", "Free"),  # 100
     SubXBitfield(20, 2, 0, 4, "Blue Goomi #1", ["Defeat Dialga", "Surrounded Sea"], "Filler", "Manaphy"),
     SubXBitfield(21, 2, 0, 5, "Blue Goomi #2", ["Defeat Dialga", "Surrounded Sea"], "Filler", "Manaphy"),
-    SubXBitfield(22, 2, 0, 6, "Manaphy Healed", ["Defeat Dialga", "Surrounded Sea", "Miracle Sea"], "Filler", "Manaphy"),
-    SubXBitfield(23, 2, 0, 7, "Manaphy's Gift", ["Defeat Dialga", "Surrounded Sea", "Miracle Sea"], "Manaphy", "Manaphy"),
+    SubXBitfield(
+        22, 2, 0, 6, "Manaphy Healed", ["Defeat Dialga", "Surrounded Sea", "Miracle Sea"], "Filler", "Manaphy"
+    ),
+    SubXBitfield(
+        23, 2, 0, 7, "Manaphy's Gift", ["Defeat Dialga", "Surrounded Sea", "Miracle Sea"], "Manaphy", "Manaphy"
+    ),
     SubXBitfield(24, 2, 1, 0, "Manaphy's Discovery", ["Defeat Dialga", "Manaphy"], "Marine Resort", "Manaphy"),
     SubXBitfield(25, 2, 1, 1, "Uxie's Gift", ["Defeat Dialga", "Steam Cave"], "Uxie", "Legendary"),
     SubXBitfield(26, 2, 1, 2, "Mesprit's Gift", ["Defeat Dialga", "Quicksand Cave"], "Mesprit", "Legendary"),
     SubXBitfield(27, 2, 1, 3, "Azelf's Gift", ["Defeat Dialga", "Crystal Crossing"], "Azelf", "Legendary"),
-    SubXBitfield(28, 2, 1, 4, "Dialga's Gift", ["Defeat Dialga", "Temporal Tower", "Hidden Land"], "Dialga", "Legendary"),
-    SubXBitfield(29, 2, 1, 5, "Phione's Gift", ["Defeat Dialga", "Surrounded Sea", "Miracle Sea"], "Phione",
-                 "Legendary"),
-
-    SubXBitfield(30, 2, 1, 6, "Palkia's Gift", ["Defeat Dialga", "Spacial Rift"], "Dialga",
-                 "Legendary"),
-    SubXBitfield(31, 2, 1, 7, "Aqua-Monica Location", ["Defeat Dialga", "Secret Rank", "Bottomless Sea"], "Aqua-Monica",
-                 "Instrument"),
-    SubXBitfield(32, 3, 0, 0, "Kyogre's Gift", ["Defeat Dialga", "Secret Rank", "Bottomless Sea"], "Kyogre",
-                 "Legendary"),
-    SubXBitfield(33, 3, 0, 1, "Terra Cymbal Location", ["Defeat Dialga", "Secret Rank", "Shimmer Desert"],
-                 "Terra Cymbal", "Instrument"),
-    SubXBitfield(34, 3, 0, 2, "Groudon's Gift", ["Defeat Dialga", "Secret Rank", "Shimmer Desert"], "Groudon",
-                 "Legendary"),
-    SubXBitfield(35, 3, 0, 3, "Icy Flute Location", ["Defeat Dialga", "Secret Rank", "Mt. Avalanche"], "Icy Flute",
-                 "Instrument"),
-    SubXBitfield(36, 3, 0, 4, "Articuno's Gift", ["Defeat Dialga", "Secret Rank", "Mt. Avalanche"], "Articuno",
-                 "Legendary"),
-    SubXBitfield(37, 3, 0, 5, "Fiery Drum Location", ["Defeat Dialga", "Secret Rank", "Giant Volcano"], "Fiery Drum",
-                 "Instrument"),
-    SubXBitfield(38, 3, 0, 6, "Heatran's Gift", ["Defeat Dialga", "Secret Rank", "Giant Volcano"], "Heatran",
-                 "Legendary"),
-    SubXBitfield(39, 3, 0, 7, "Rock Horn Location", ["Defeat Dialga", "Secret Rank", "World Abyss"], "Rock Horn",
-                 "Instrument"),
-    SubXBitfield(40, 3, 1, 0, "Giratina's Gift", ["Defeat Dialga", "Secret Rank", "World Abyss"], "Giratina",
-                 "Legendary"),
-    SubXBitfield(41, 3, 1, 1, "Sky Melodica Location", ["Defeat Dialga", "Secret Rank", "Sky Stairway"],
-                 "Sky Melodica", "Instrument"),
-    SubXBitfield(42, 3, 1, 2, "Rayquaza's Gift", ["Defeat Dialga", "Secret Rank", "Sky Stairway"], "Rayquaza",
-                 "Legendary"),
-    SubXBitfield(43, 3, 1, 3, "Grass Cornet Location", ["Defeat Dialga", "Secret Rank", "Mystery Jungle"],
-                 "Grass Cornet", "Instrument"),
-    SubXBitfield(44, 3, 1, 4, "Mew's Gift", ["Defeat Dialga", "Secret Rank", "Mystery Jungle"], "Mew",
-                 "Legendary"),
+    SubXBitfield(
+        28, 2, 1, 4, "Dialga's Gift", ["Defeat Dialga", "Temporal Tower", "Hidden Land"], "Dialga", "Legendary"
+    ),
+    SubXBitfield(
+        29, 2, 1, 5, "Phione's Gift", ["Defeat Dialga", "Surrounded Sea", "Miracle Sea"], "Phione", "Legendary"
+    ),
+    SubXBitfield(30, 2, 1, 6, "Palkia's Gift", ["Defeat Dialga", "Spacial Rift"], "Dialga", "Legendary"),
+    SubXBitfield(
+        31,
+        2,
+        1,
+        7,
+        "Aqua-Monica Location",
+        ["Defeat Dialga", "Secret Rank", "Bottomless Sea"],
+        "Aqua-Monica",
+        "Instrument",
+    ),
+    SubXBitfield(
+        32, 3, 0, 0, "Kyogre's Gift", ["Defeat Dialga", "Secret Rank", "Bottomless Sea"], "Kyogre", "Legendary"
+    ),
+    SubXBitfield(
+        33,
+        3,
+        0,
+        1,
+        "Terra Cymbal Location",
+        ["Defeat Dialga", "Secret Rank", "Shimmer Desert"],
+        "Terra Cymbal",
+        "Instrument",
+    ),
+    SubXBitfield(
+        34, 3, 0, 2, "Groudon's Gift", ["Defeat Dialga", "Secret Rank", "Shimmer Desert"], "Groudon", "Legendary"
+    ),
+    SubXBitfield(
+        35, 3, 0, 3, "Icy Flute Location", ["Defeat Dialga", "Secret Rank", "Mt. Avalanche"], "Icy Flute", "Instrument"
+    ),
+    SubXBitfield(
+        36, 3, 0, 4, "Articuno's Gift", ["Defeat Dialga", "Secret Rank", "Mt. Avalanche"], "Articuno", "Legendary"
+    ),
+    SubXBitfield(
+        37,
+        3,
+        0,
+        5,
+        "Fiery Drum Location",
+        ["Defeat Dialga", "Secret Rank", "Giant Volcano"],
+        "Fiery Drum",
+        "Instrument",
+    ),
+    SubXBitfield(
+        38, 3, 0, 6, "Heatran's Gift", ["Defeat Dialga", "Secret Rank", "Giant Volcano"], "Heatran", "Legendary"
+    ),
+    SubXBitfield(
+        39, 3, 0, 7, "Rock Horn Location", ["Defeat Dialga", "Secret Rank", "World Abyss"], "Rock Horn", "Instrument"
+    ),
+    SubXBitfield(
+        40, 3, 1, 0, "Giratina's Gift", ["Defeat Dialga", "Secret Rank", "World Abyss"], "Giratina", "Legendary"
+    ),
+    SubXBitfield(
+        41,
+        3,
+        1,
+        1,
+        "Sky Melodica Location",
+        ["Defeat Dialga", "Secret Rank", "Sky Stairway"],
+        "Sky Melodica",
+        "Instrument",
+    ),
+    SubXBitfield(
+        42, 3, 1, 2, "Rayquaza's Gift", ["Defeat Dialga", "Secret Rank", "Sky Stairway"], "Rayquaza", "Legendary"
+    ),
+    SubXBitfield(
+        43,
+        3,
+        1,
+        3,
+        "Grass Cornet Location",
+        ["Defeat Dialga", "Secret Rank", "Mystery Jungle"],
+        "Grass Cornet",
+        "Instrument",
+    ),
+    SubXBitfield(44, 3, 1, 4, "Mew's Gift", ["Defeat Dialga", "Secret Rank", "Mystery Jungle"], "Mew", "Legendary"),
     SubXBitfield(45, 3, 1, 5, "Cresselia's Gift", ["Defeat Dialga"], "Cresselia", "Legendary"),
     SubXBitfield(46, 3, 1, 6, "Shaymin's Gift", ["Defeat Dialga", "Sky Peak Summit Pass"], "Shaymin", "Legendary"),
     SubXBitfield(47, 3, 1, 7, "Scizor's Gift", ["Defeat Dialga", "Crevice Cave"], "Secret Rank", "SecretRank"),
@@ -83,34 +138,71 @@ subX_table = [
     SubXBitfield(49, 4, 0, 1, "Terra Cymbal Mission", ["Secret Rank", "Shimmer Desert"], "Shimmer Desert", "LateSubX"),
     SubXBitfield(50, 4, 0, 2, "Icy Flute Mission", ["Secret Rank", "Mt. Avalanche"], "Mt. Avalanche", "LateSubX"),
     SubXBitfield(51, 4, 0, 3, "Fiery Drum Mission", ["Secret Rank", "Giant Volcano"], "Giant Volcano", "LateSubX"),
-    SubXBitfield(52, 4, 0, 4, "Rock Horn Mission", ["Secret Rank",  "World Abyss"], "World Abyss", "LateSubX"),
+    SubXBitfield(52, 4, 0, 4, "Rock Horn Mission", ["Secret Rank", "World Abyss"], "World Abyss", "LateSubX"),
     SubXBitfield(53, 4, 0, 5, "Sky Melodica Mission", ["Secret Rank", "Sky Stairway"], "Sky Stairway", "LateSubX"),
     SubXBitfield(54, 4, 0, 6, "Grass Cornet Mission", ["Secret Rank", "Mystery Jungle"], "Mystery Jungle", "LateSubX"),
     SubXBitfield(55, 4, 0, 7, "Master ★ Rank", ["Secret Rank", "Defeat Dialga"], "Treacherous Waters", "Rank"),
     SubXBitfield(56, 4, 1, 0, "Master ★★ Rank", ["Secret Rank", "Defeat Dialga"], "Southeastern Islands", "Rank"),
     SubXBitfield(57, 4, 1, 1, "Master ★★★ Rank", ["Secret Rank", "Defeat Dialga"], "Inferno Cave", "Rank"),
-    SubXBitfield(58, 4, 1, 2, "Guildmaster Rank", ["Secret Rank", "Defeat Dialga", "ProgressiveBag3"], "Inferno Cave", "Rank"),
+    SubXBitfield(
+        58, 4, 1, 2, "Guildmaster Rank", ["Secret Rank", "Defeat Dialga", "ProgressiveBag3"], "Inferno Cave", "Rank"
+    ),
     SubXBitfield(59, 4, 1, 3, "Recycle Shop Treasure Found", ["Main Game"], "Filler", "ShopItem"),
-    SubXBitfield(60, 4, 1, 4, "Recycle Shop Dungeon #1", ["ProgressiveBag3", "Main Game"], "Landslide Cave", "ShopItem"),
+    SubXBitfield(
+        60, 4, 1, 4, "Recycle Shop Dungeon #1", ["ProgressiveBag3", "Main Game"], "Landslide Cave", "ShopItem"
+    ),
     SubXBitfield(61, 4, 1, 5, "Recycle Shop Dungeon #2", ["ProgressiveBag3", "Main Game"], "Tiny Meadow", "ShopItem"),
     SubXBitfield(62, 4, 1, 6, "Recycle Shop Dungeon #3", ["ProgressiveBag3", "Main Game"], "Oran Forest", "ShopItem"),
-    SubXBitfield(63, 4, 1, 7, "Recycle Shop Dungeon #4", ["ProgressiveBag3", "Main Game", "Defeat Dialga", "Formation Control"], "Lake Afar",
-                 "ShopItem"),
-    SubXBitfield(64, 5, 0, 0, "Recycle Shop Dungeon #5", ["ProgressiveBag3", "Defeat Dialga",
-                                                          "Formation Control", "Main Game"], "Zero Isle Center", "ShopItem"),
-    SubXBitfield(65, 5, 0, 1, "Sneasel's Gratitude", ["Defeat Dialga", "7th Station Pass", "Sky Peak Summit Pass"],
-                 "Filler", "LateSubX"),
-    SubXBitfield(66, 5, 0, 2, "SE Marowak Dojo's Revival", ["Bidoof\'s Wish"], "Filler", "SpecialDungeonComplete"),
+    SubXBitfield(
+        63,
+        4,
+        1,
+        7,
+        "Recycle Shop Dungeon #4",
+        ["ProgressiveBag3", "Main Game", "Defeat Dialga", "Formation Control"],
+        "Lake Afar",
+        "ShopItem",
+    ),
+    SubXBitfield(
+        64,
+        5,
+        0,
+        0,
+        "Recycle Shop Dungeon #5",
+        ["ProgressiveBag3", "Defeat Dialga", "Formation Control", "Main Game"],
+        "Zero Isle Center",
+        "ShopItem",
+    ),
+    SubXBitfield(
+        65,
+        5,
+        0,
+        1,
+        "Sneasel's Gratitude",
+        ["Defeat Dialga", "7th Station Pass", "Sky Peak Summit Pass"],
+        "Filler",
+        "LateSubX",
+    ),
+    SubXBitfield(66, 5, 0, 2, "SE Marowak Dojo's Revival", ["Bidoof's Wish"], "Filler", "SpecialDungeonComplete"),
     SubXBitfield(67, 5, 0, 3, "Clear All Marowak Mazes", ["All Mazes"], "Filler", "OptionalSubX"),
     SubXBitfield(68, 5, 0, 4, "Grandpa's Treasure", ["Dojo Final Maze"], "Filler", "OptionalSubX"),
-    SubXBitfield(69, 5, 0, 5, "Regice's Gift", ["Defeat Dialga", "Ice Seal", "Ice Aegis Cave"], "Regice",
-                 "Legendary"),
-    SubXBitfield(70, 5, 0, 6, "Regirock's Gift", ["Defeat Dialga", "Rock Seal", "Ice Aegis Cave"], "Regirock",
-                 "Legendary"),
-    SubXBitfield(71, 5, 0, 7, "Registeel's Gift", ["Defeat Dialga", "Steel Seal", "Ice Aegis Cave"], "Registeel",
-                 "Legendary"),
-    SubXBitfield(72, 5, 1, 0, "Regigigas's Gift", ["Defeat Dialga", "Ice Seal", "Rock Seal", "Steel Seal",
-                                                   "Ice Aegis Cave"], "Regigigas", "Legendary"),
+    SubXBitfield(69, 5, 0, 5, "Regice's Gift", ["Defeat Dialga", "Ice Seal", "Ice Aegis Cave"], "Regice", "Legendary"),
+    SubXBitfield(
+        70, 5, 0, 6, "Regirock's Gift", ["Defeat Dialga", "Rock Seal", "Ice Aegis Cave"], "Regirock", "Legendary"
+    ),
+    SubXBitfield(
+        71, 5, 0, 7, "Registeel's Gift", ["Defeat Dialga", "Steel Seal", "Ice Aegis Cave"], "Registeel", "Legendary"
+    ),
+    SubXBitfield(
+        72,
+        5,
+        1,
+        0,
+        "Regigigas's Gift",
+        ["Defeat Dialga", "Ice Seal", "Rock Seal", "Steel Seal", "Ice Aegis Cave"],
+        "Regigigas",
+        "Legendary",
+    ),
     SubXBitfield(73, 5, 1, 1, "Bronze Rank", ["3 Early"], "Filler", "Rank"),
     SubXBitfield(74, 5, 1, 2, "Silver Rank", ["3 Early"], "Filler", "Rank"),
     SubXBitfield(75, 5, 1, 3, "Gold Rank", ["3 Early"], "Filler", "Rank"),
@@ -125,7 +217,9 @@ subX_table = [
     SubXBitfield(84, 6, 0, 4, "Duskull 20,000G Reward", ["ProgressiveBag2", "Main Game"], "Filler", "ShopItem"),
     SubXBitfield(85, 6, 0, 5, "Duskull 50,000G Reward", ["ProgressiveBag3"], "Filler", "OptionalSubX"),
     SubXBitfield(86, 6, 0, 6, "Duskull 100,000G Reward", ["ProgressiveBag3"], "Filler", "OptionalSubX"),
-    SubXBitfield(87, 6, 0, 7, "Duskull 9,999,999G Reward", ["ProgressiveBag3", "Defeat Dialga"], "Filler", "OptionalSubX"),
+    SubXBitfield(
+        87, 6, 0, 7, "Duskull 9,999,999G Reward", ["ProgressiveBag3", "Defeat Dialga"], "Filler", "OptionalSubX"
+    ),
     SubXBitfield(88, 6, 1, 0, "Ludicolo Dance", ["ProgressiveBag1"], "Filler", "OptionalSubX"),
     SubXBitfield(89, 6, 1, 1, "Unused", ["-"], "-"),
     SubXBitfield(90, 6, 1, 2, "Unused", ["-"], "-"),
@@ -165,5 +259,5 @@ subX_table = [
     SubXBitfield(124, 8, 1, 4, "Unused", ["-"], "-"),
     SubXBitfield(125, 8, 1, 5, "Unused", ["-"], "-"),
     SubXBitfield(126, 8, 1, 6, "Unused", ["-"], "-"),
-    SubXBitfield(127, 8, 1, 7, "Team Name Location", ["Main Game"], "Team Name Trap", "Team Name")
+    SubXBitfield(127, 8, 1, 7, "Team Name Location", ["Main Game"], "Team Name Trap", "Team Name"),
 ]

--- a/worlds/pmd_eos/Rules.py
+++ b/worlds/pmd_eos/Rules.py
@@ -20,47 +20,64 @@ def set_rules(world: "EOSWorld", excluded):
     spinda_drink_events(world, player)
 
     if world.options.goal.value == 0:
-        set_rule(world.multiworld.get_location("Final Boss", player),
-                 lambda state: state.has("Temporal Tower", player) and has_relic_shards(state, player, world))
+        set_rule(
+            world.multiworld.get_location("Final Boss", player),
+            lambda state: state.has("Temporal Tower", player) and has_relic_shards(state, player, world),
+        )
         if special_episode_sanity_no_exclusion(world, player):
-            add_rule(world.multiworld.get_location("Final Boss", player),
-                     lambda state: state.has("Main Game Unlock", player))
+            add_rule(
+                world.multiworld.get_location("Final Boss", player), lambda state: state.has("Main Game Unlock", player)
+            )
 
-        #set_rule(world.multiworld.get_location("Dark Crater", player),
-        #lambda state: state.has("Dark Crater", player) and ready_for_late_game(state, player, world))
+        # set_rule(world.multiworld.get_location("Dark Crater", player),
+        # lambda state: state.has("Dark Crater", player) and ready_for_late_game(state, player, world))
 
     elif world.options.goal.value == 1:
-        set_rule(world.multiworld.get_location("Final Boss", player),
-                 lambda state: ready_for_darkrai(state, player, world))
+        set_rule(
+            world.multiworld.get_location("Final Boss", player), lambda state: ready_for_darkrai(state, player, world)
+        )
         if special_episode_sanity_no_exclusion(world, player):
-            add_rule(world.multiworld.get_location("Final Boss", player),
-                     lambda state: state.has("Main Game Unlock", player))
-        set_rule(world.multiworld.get_location("Dark Crater", player),
-                 lambda state: ready_for_darkrai(state, player, world))
+            add_rule(
+                world.multiworld.get_location("Final Boss", player), lambda state: state.has("Main Game Unlock", player)
+            )
+        set_rule(
+            world.multiworld.get_location("Dark Crater", player), lambda state: ready_for_darkrai(state, player, world)
+        )
         if special_episode_sanity_no_exclusion(world, player):
-            add_rule(world.multiworld.get_location("Dark Crater", player),
-                     lambda state: state.has("Main Game Unlock", player))
-        set_rule(world.multiworld.get_location("The Nightmare", player),
-                 lambda state: state.can_reach_location("Mt. Bristle", player) and state.has("The Nightmare", player)
-                               and ready_for_late_game(state, player, world))
+            add_rule(
+                world.multiworld.get_location("Dark Crater", player),
+                lambda state: state.has("Main Game Unlock", player),
+            )
+        set_rule(
+            world.multiworld.get_location("The Nightmare", player),
+            lambda state: state.can_reach_location("Mt. Bristle", player)
+            and state.has("The Nightmare", player)
+            and ready_for_late_game(state, player, world),
+        )
         if special_episode_sanity_no_exclusion(world, player):
-            add_rule(world.multiworld.get_location("The Nightmare", player),
-                     lambda state: state.has("Main Game Unlock", player))
+            add_rule(
+                world.multiworld.get_location("The Nightmare", player),
+                lambda state: state.has("Main Game Unlock", player),
+            )
 
-    set_rule(world.multiworld.get_entrance("Late Game Door", player),
-             lambda state: ready_for_late_game(state, player, world))
+    set_rule(
+        world.multiworld.get_entrance("Late Game Door", player), lambda state: ready_for_late_game(state, player, world)
+    )
 
-    set_rule(world.multiworld.get_location("Hidden Land", player),
-             lambda state: has_relic_shards(state, player, world))
+    set_rule(world.multiworld.get_location("Hidden Land", player), lambda state: has_relic_shards(state, player, world))
     if special_episode_sanity_no_exclusion(world, player):
-        add_rule(world.multiworld.get_location("Hidden Land", player),
-                 lambda state: state.has("Main Game Unlock", player))
+        add_rule(
+            world.multiworld.get_location("Hidden Land", player), lambda state: state.has("Main Game Unlock", player)
+        )
 
-    set_rule(world.multiworld.get_location("Temporal Tower", player),
-             lambda state: state.has("Temporal Tower", player) and has_relic_shards(state, player, world))
+    set_rule(
+        world.multiworld.get_location("Temporal Tower", player),
+        lambda state: state.has("Temporal Tower", player) and has_relic_shards(state, player, world),
+    )
     if special_episode_sanity_no_exclusion(world, player):
-        add_rule(world.multiworld.get_location("Temporal Tower", player),
-                 lambda state: state.has("Main Game Unlock", player))
+        add_rule(
+            world.multiworld.get_location("Temporal Tower", player), lambda state: state.has("Main Game Unlock", player)
+        )
 
 
 def has_relic_shards(state, player, world):
@@ -68,28 +85,40 @@ def has_relic_shards(state, player, world):
 
 
 def ready_for_late_game(state, player, world):
-    return (state.has_group("EarlyDungeons", player, 10)
-            and state.has("Relic Fragment Shard", player, world.options.required_fragments.value)
-            and state.has("Temporal Tower", player))
+    return (
+        state.has_group("EarlyDungeons", player, 10)
+        and state.has("Relic Fragment Shard", player, world.options.required_fragments.value)
+        and state.has("Temporal Tower", player)
+    )
 
 
 def spinda_drink_events(world, player):
     de_amount = world.options.drink_events.value
     sdrinks_amount = world.options.spinda_drinks.value
     for i in range(de_amount):
-        set_rule(world.multiworld.get_location("Spinda Drink Event " + str(i + 1), player),
-                 lambda state: state.has("Bag Upgrade", player, 3))
+        set_rule(
+            world.multiworld.get_location("Spinda Drink Event " + str(i + 1), player),
+            lambda state: state.has("Bag Upgrade", player, 3),
+        )
         if special_episode_sanity_no_exclusion(world, player):
-            add_rule(world.multiworld.get_location("Spinda Drink Event " + str(i + 1), player),
-                     lambda state: state.has("Main Game Unlock", player) or state.has("Bidoof\'s Wish", player)
-                                   or state.has('Today\'s "Oh My Gosh"', player))
+            add_rule(
+                world.multiworld.get_location("Spinda Drink Event " + str(i + 1), player),
+                lambda state: state.has("Main Game Unlock", player)
+                or state.has("Bidoof's Wish", player)
+                or state.has('Today\'s "Oh My Gosh"', player),
+            )
     for i in range(sdrinks_amount):
-        set_rule(world.multiworld.get_location("Spinda Drink " + str(i + 1), player),
-                 lambda state: state.has("Bag Upgrade", player))
+        set_rule(
+            world.multiworld.get_location("Spinda Drink " + str(i + 1), player),
+            lambda state: state.has("Bag Upgrade", player),
+        )
         if special_episode_sanity_no_exclusion(world, player):
-            add_rule(world.multiworld.get_location("Spinda Drink " + str(i + 1), player),
-                     lambda state: state.has("Main Game Unlock", player) or state.has("Bidoof\'s Wish", player)
-                                   or state.has('Today\'s "Oh My Gosh"', player))
+            add_rule(
+                world.multiworld.get_location("Spinda Drink " + str(i + 1), player),
+                lambda state: state.has("Main Game Unlock", player)
+                or state.has("Bidoof's Wish", player)
+                or state.has('Today\'s "Oh My Gosh"', player),
+            )
 
 
 def forbid_items_behind_locations(world, player):
@@ -112,210 +141,321 @@ def forbid_items_behind_locations(world, player):
         for i in range(111, 120):
             location = location_Dict_by_id[i]
             for j in range(world.options.late_mission_checks.value):
-                forbid_item(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                            "Progressive Sky Peak", player)
+                forbid_item(
+                    world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                    "Progressive Sky Peak",
+                    player,
+                )
             for j in range(world.options.late_outlaw_checks.value):
-                forbid_item(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                            "Progressive Sky Peak", player)
+                forbid_item(
+                    world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                    "Progressive Sky Peak",
+                    player,
+                )
 
 
 def special_episodes_rules(world, player):
     if not world.options.exclude_special.value:
         # Bidoof Special Episode Checks
-        set_rule(world.multiworld.get_location("SE Deep Star Cave", player),
-                 lambda state: state.has("Bidoof\'s Wish", player))
-        set_rule(world.multiworld.get_location("SE Star Cave Pit", player),
-                 lambda state: state.has("Bidoof\'s Wish", player))
+        set_rule(
+            world.multiworld.get_location("SE Deep Star Cave", player), lambda state: state.has("Bidoof's Wish", player)
+        )
+        set_rule(
+            world.multiworld.get_location("SE Star Cave Pit", player), lambda state: state.has("Bidoof's Wish", player)
+        )
 
         # Igglybuff Special Episode checks
-        set_rule(world.multiworld.get_location("SE Murky Forest", player),
-                 lambda state: state.has("Igglybuff the Prodigy", player))
-        set_rule(world.multiworld.get_location("SE Eastern Cave", player),
-                 lambda state: state.has("Igglybuff the Prodigy", player))
-        set_rule(world.multiworld.get_location("SE Fortune Ravine", player),
-                 lambda state: state.has("Igglybuff the Prodigy", player))
+        set_rule(
+            world.multiworld.get_location("SE Murky Forest", player),
+            lambda state: state.has("Igglybuff the Prodigy", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Eastern Cave", player),
+            lambda state: state.has("Igglybuff the Prodigy", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Fortune Ravine", player),
+            lambda state: state.has("Igglybuff the Prodigy", player),
+        )
 
         # Grovyle and Dusknoir Special Episode Checks
-        set_rule(world.multiworld.get_location("In the Future of Darkness Location", player),
-                 lambda state: has_relic_shards(state, player, world))
-        set_rule(world.multiworld.get_location("SE Barren Valley", player),
-                 lambda state: state.has("In the Future of Darkness", player))
-        set_rule(world.multiworld.get_location("SE Dark Wasteland", player),
-                 lambda state: state.has("In the Future of Darkness", player))
-        set_rule(world.multiworld.get_location("SE Temporal Tower", player),
-                 lambda state: state.has("In the Future of Darkness", player))
-        set_rule(world.multiworld.get_location("SE Dusk Forest", player),
-                 lambda state: state.has("In the Future of Darkness", player))
-        set_rule(world.multiworld.get_location("SE Spacial Cliffs", player),
-                 lambda state: state.has("In the Future of Darkness", player))
-        set_rule(world.multiworld.get_location("SE Dark Ice Mountain", player),
-                 lambda state: state.has("In the Future of Darkness", player))
-        set_rule(world.multiworld.get_location("SE Icicle Forest", player),
-                 lambda state: state.has("In the Future of Darkness", player))
-        set_rule(world.multiworld.get_location("SE Vast Ice Mountain", player),
-                 lambda state: state.has("In the Future of Darkness", player))
+        set_rule(
+            world.multiworld.get_location("In the Future of Darkness Location", player),
+            lambda state: has_relic_shards(state, player, world),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Barren Valley", player),
+            lambda state: state.has("In the Future of Darkness", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Dark Wasteland", player),
+            lambda state: state.has("In the Future of Darkness", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Temporal Tower", player),
+            lambda state: state.has("In the Future of Darkness", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Dusk Forest", player),
+            lambda state: state.has("In the Future of Darkness", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Spacial Cliffs", player),
+            lambda state: state.has("In the Future of Darkness", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Dark Ice Mountain", player),
+            lambda state: state.has("In the Future of Darkness", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Icicle Forest", player),
+            lambda state: state.has("In the Future of Darkness", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Vast Ice Mountain", player),
+            lambda state: state.has("In the Future of Darkness", player),
+        )
 
         # Team Charm Special Episode Checks
-        set_rule(world.multiworld.get_location("SE Southern Jungle", player),
-                 lambda state: state.has("Here Comes Team Charm!", player))
-        set_rule(world.multiworld.get_location("SE Boulder Quarry", player),
-                 lambda state: state.has("Here Comes Team Charm!", player))
-        set_rule(world.multiworld.get_location("SE Right Cave Path", player),
-                 lambda state: state.has("Here Comes Team Charm!", player))
-        set_rule(world.multiworld.get_location("SE Left Cave Path", player),
-                 lambda state: state.has("Here Comes Team Charm!", player))
-        set_rule(world.multiworld.get_location("SE Limestone Cavern", player),
-                 lambda state: state.has("Here Comes Team Charm!", player))
+        set_rule(
+            world.multiworld.get_location("SE Southern Jungle", player),
+            lambda state: state.has("Here Comes Team Charm!", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Boulder Quarry", player),
+            lambda state: state.has("Here Comes Team Charm!", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Right Cave Path", player),
+            lambda state: state.has("Here Comes Team Charm!", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Left Cave Path", player),
+            lambda state: state.has("Here Comes Team Charm!", player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Limestone Cavern", player),
+            lambda state: state.has("Here Comes Team Charm!", player),
+        )
 
         # Sunflora Special Episode Checks
-        set_rule(world.multiworld.get_location("SE Upper Spring Cave", player),
-                 lambda state: state.has('Today\'s "Oh My Gosh"', player))
-        set_rule(world.multiworld.get_location("SE Middle Spring Cave", player),
-                 lambda state: state.has('Today\'s "Oh My Gosh"', player))
-        set_rule(world.multiworld.get_location("SE Spring Cave Pit", player),
-                 lambda state: state.has('Today\'s "Oh My Gosh"', player))
+        set_rule(
+            world.multiworld.get_location("SE Upper Spring Cave", player),
+            lambda state: state.has('Today\'s "Oh My Gosh"', player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Middle Spring Cave", player),
+            lambda state: state.has('Today\'s "Oh My Gosh"', player),
+        )
+        set_rule(
+            world.multiworld.get_location("SE Spring Cave Pit", player),
+            lambda state: state.has('Today\'s "Oh My Gosh"', player),
+        )
 
 
 def ready_for_darkrai(state, player, world):
-    return (state.has("Relic Fragment Shard", player, world.options.required_fragments.value)
-            and state.has("Temporal Tower", player)
-            and state.has_group("Instrument", player, world.options.req_instruments.value)
-            and state.has_group("LateDungeons", player, 10))
+    return (
+        state.has("Relic Fragment Shard", player, world.options.required_fragments.value)
+        and state.has("Temporal Tower", player)
+        and state.has_group("Instrument", player, world.options.req_instruments.value)
+        and state.has_group("LateDungeons", player, 10)
+    )
 
 
 def dungeon_locations_behind_items(world, player):
     for location in EOS_location_table:
         if location.name == "Beach Cave":
             if special_episode_sanity_no_exclusion(world, player):
-                add_rule(world.multiworld.get_location(location.name, player),
-                         lambda state: state.has("Main Game Unlock", player))
+                add_rule(
+                    world.multiworld.get_location(location.name, player),
+                    lambda state: state.has("Main Game Unlock", player),
+                )
             continue
         elif "Early" in location.group:
-            set_rule(world.multiworld.get_location(location.name, player),
-                     lambda state, ln=location.name: state.has(ln, player))
+            set_rule(
+                world.multiworld.get_location(location.name, player),
+                lambda state, ln=location.name: state.has(ln, player),
+            )
             if special_episode_sanity_no_exclusion(world, player):
-                add_rule(world.multiworld.get_location(location.name, player),
-                         lambda state: state.has("Main Game Unlock", player))
+                add_rule(
+                    world.multiworld.get_location(location.name, player),
+                    lambda state: state.has("Main Game Unlock", player),
+                )
         elif "Dojo" in location.group:
-            set_rule(world.multiworld.get_location(location.name, player),
-                     lambda state, ln=location.name: state.has(ln, player))
+            set_rule(
+                world.multiworld.get_location(location.name, player),
+                lambda state, ln=location.name: state.has(ln, player),
+            )
             if special_episode_sanity_no_exclusion(world, player):
-                add_rule(world.multiworld.get_location(location.name, player),
-                         lambda state: state.has("Main Game Unlock", player) or state.has("Bidoof\'s Wish", player)
-                                       or state.has('Today\'s "Oh My Gosh"', player))
+                add_rule(
+                    world.multiworld.get_location(location.name, player),
+                    lambda state: state.has("Main Game Unlock", player)
+                    or state.has("Bidoof's Wish", player)
+                    or state.has('Today\'s "Oh My Gosh"', player),
+                )
         elif "Station" in location.group and world.options.goal.value == 1:
             if world.options.sky_peak_type.value == 1:  # progressive
                 if location.name == "Sky Peak Summit":
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Progressive Sky Peak", player, 10)
-                                           and ready_for_late_game(state, player, world))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Progressive Sky Peak", player, 10)
+                        and ready_for_late_game(state, player, world),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
                 elif location.name == "5th Station Clearing":
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Progressive Sky Peak", player, 5)
-                                           and ready_for_late_game(state, player, world))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Progressive Sky Peak", player, 5)
+                        and ready_for_late_game(state, player, world),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
                 else:
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state, req_num=(location.id - 110):
-                             state.has("Progressive Sky Peak", player, req_num)
-                             and ready_for_late_game(state, player, world))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state, req_num=(location.id - 110): state.has("Progressive Sky Peak", player, req_num)
+                        and ready_for_late_game(state, player, world),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
 
             elif world.options.sky_peak_type.value == 2:  # all random
                 if location.name == "Sky Peak Summit":
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Sky Peak Summit Pass", player)
-                                           and ready_for_late_game(state, player, world))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Sky Peak Summit Pass", player)
+                        and ready_for_late_game(state, player, world),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
                 elif location.name == "5th Station Clearing":
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("5th Station Pass", player)
-                                           and ready_for_late_game(state, player, world))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("5th Station Pass", player)
+                        and ready_for_late_game(state, player, world),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
                 else:
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state, ln=location.name: state.has(ln, player)
-                                                             and ready_for_late_game(state, player, world))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state, ln=location.name: state.has(ln, player)
+                        and ready_for_late_game(state, player, world),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
 
             elif world.options.sky_peak_type.value == 3:  # all open from 1st station pass
-                set_rule(world.multiworld.get_location(location.name, player),
-                         lambda state: state.has("1st Station Pass", player)
-                                       and ready_for_late_game(state, player, world))
+                set_rule(
+                    world.multiworld.get_location(location.name, player),
+                    lambda state: state.has("1st Station Pass", player) and ready_for_late_game(state, player, world),
+                )
                 if special_episode_sanity_no_exclusion(world, player):
-                    add_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Main Game Unlock", player))
+                    add_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Main Game Unlock", player),
+                    )
         elif "Aegis" in location.group and world.options.goal.value == 1:
             if world.options.cursed_aegis_cave.value == 0:
                 if location.id in [54]:
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Ice Aegis Cave", player)
-                                           and ready_for_late_game(state, player, world))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Ice Aegis Cave", player) and ready_for_late_game(state, player, world),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
                 elif location.id in [55, 56]:  # Regice Chamber
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Ice Aegis Cave", player)
-                                           and ready_for_late_game(state, player, world)
-                                           and state.has("Progressive Seal", player, 1))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Ice Aegis Cave", player)
+                        and ready_for_late_game(state, player, world)
+                        and state.has("Progressive Seal", player, 1),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
                 elif location.id in [57, 58]:  # Regirock Chamber
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Ice Aegis Cave", player)
-                                           and ready_for_late_game(state, player, world)
-                                           and state.has("Progressive Seal", player, 2))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Ice Aegis Cave", player)
+                        and ready_for_late_game(state, player, world)
+                        and state.has("Progressive Seal", player, 2),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
                 elif location.id in [59, 60, 61]:  # Registeel Chamber
-                    set_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Ice Aegis Cave", player)
-                                           and ready_for_late_game(state, player, world)
-                                           and state.has("Progressive Seal", player, 3))
+                    set_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Ice Aegis Cave", player)
+                        and ready_for_late_game(state, player, world)
+                        and state.has("Progressive Seal", player, 3),
+                    )
                     if special_episode_sanity_no_exclusion(world, player):
-                        add_rule(world.multiworld.get_location(location.name, player),
-                                 lambda state: state.has("Main Game Unlock", player))
+                        add_rule(
+                            world.multiworld.get_location(location.name, player),
+                            lambda state: state.has("Main Game Unlock", player),
+                        )
 
             else:
-                set_rule(world.multiworld.get_location(location.name, player),
-                         lambda state: state.has("Ice Aegis Cave", player)
-                                       and ready_for_late_game(state, player, world))
+                set_rule(
+                    world.multiworld.get_location(location.name, player),
+                    lambda state: state.has("Ice Aegis Cave", player) and ready_for_late_game(state, player, world),
+                )
                 if special_episode_sanity_no_exclusion(world, player):
-                    add_rule(world.multiworld.get_location(location.name, player),
-                             lambda state: state.has("Main Game Unlock", player))
+                    add_rule(
+                        world.multiworld.get_location(location.name, player),
+                        lambda state: state.has("Main Game Unlock", player),
+                    )
 
         elif "Late" in location.group and world.options.goal.value == 1:
-            set_rule(world.multiworld.get_location(location.name, player),
-                     lambda state, ln=location.name: state.has(ln, player) and ready_for_late_game(state, player,
-                                                                                                   world))
+            set_rule(
+                world.multiworld.get_location(location.name, player),
+                lambda state, ln=location.name: state.has(ln, player) and ready_for_late_game(state, player, world),
+            )
             if special_episode_sanity_no_exclusion(world, player):
-                add_rule(world.multiworld.get_location(location.name, player),
-                         lambda state: state.has("Main Game Unlock", player))
+                add_rule(
+                    world.multiworld.get_location(location.name, player),
+                    lambda state: state.has("Main Game Unlock", player),
+                )
         elif "Rule" in location.group and world.options.goal.value == 1:
             if world.options.long_location == 0:
                 continue
-            set_rule(world.multiworld.get_location(location.name, player),
-                     lambda state, ln=location.name: state.has(ln, player) and ready_for_late_game(state, player,
-                                                                                                   world))
+            set_rule(
+                world.multiworld.get_location(location.name, player),
+                lambda state, ln=location.name: state.has(ln, player) and ready_for_late_game(state, player, world),
+            )
             if special_episode_sanity_no_exclusion(world, player):
-                add_rule(world.multiworld.get_location(location.name, player),
-                         lambda state: state.has("Main Game Unlock", player))
+                add_rule(
+                    world.multiworld.get_location(location.name, player),
+                    lambda state: state.has("Main Game Unlock", player),
+                )
         elif "Special" in location.group:
             continue
 
@@ -328,238 +468,358 @@ def mission_rules(world, player):
         if location.name == "Beach Cave":
             if special_episode_sanity_no_exclusion(world, player):
                 for j in range(world.options.early_mission_checks.value):
-                    add_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                             lambda state: state.has("Main Game Unlock", player))
+                    add_rule(
+                        world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                        lambda state: state.has("Main Game Unlock", player),
+                    )
                 for j in range(world.options.early_outlaw_checks.value):
-                    add_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                             lambda state: state.has("Main Game Unlock", player))
+                    add_rule(
+                        world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                        lambda state: state.has("Main Game Unlock", player),
+                    )
             continue
 
         elif location.classification == "EarlyDungeonComplete":
             for j in range(world.options.early_mission_checks.value):
-                set_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                         lambda state, ln=location.name, p=player: state.has(ln, p))
+                set_rule(
+                    world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                    lambda state, ln=location.name, p=player: state.has(ln, p),
+                )
                 if special_episode_sanity_no_exclusion(world, player):
-                    add_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                             lambda state: state.has("Main Game Unlock", player))
+                    add_rule(
+                        world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                        lambda state: state.has("Main Game Unlock", player),
+                    )
             for j in range(world.options.early_outlaw_checks.value):
-                set_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                         lambda state, ln=location.name, p=player: state.has(ln, p))
+                set_rule(
+                    world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                    lambda state, ln=location.name, p=player: state.has(ln, p),
+                )
                 if special_episode_sanity_no_exclusion(world, player):
-                    add_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                             lambda state: state.has("Main Game Unlock", player))
+                    add_rule(
+                        world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                        lambda state: state.has("Main Game Unlock", player),
+                    )
 
         elif location.classification in ["LateDungeonComplete", "BossDungeonComplete"]:
-
             if world.options.goal.value == 1:
                 if "Station" in location.group:
                     if world.options.sky_peak_type == 1:
                         for j in range(world.options.late_mission_checks.value):
-                            set_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                     lambda state, ln="Progressive Sky Peak", num=(location.id - 110), p=player:
-                                     state.has(ln, p, num) and ready_for_late_game(state, player, world))
+                            set_rule(
+                                world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                lambda state, ln="Progressive Sky Peak", num=(location.id - 110), p=player: state.has(
+                                    ln, p, num
+                                )
+                                and ready_for_late_game(state, player, world),
+                            )
                             if special_episode_sanity_no_exclusion(world, player):
-                                add_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                         lambda state: state.has("Main Game Unlock", player))
+                                add_rule(
+                                    world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                    lambda state: state.has("Main Game Unlock", player),
+                                )
                         for j in range(world.options.late_outlaw_checks.value):
-                            set_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                     lambda state, ln="Progressive Sky Peak", num=(location.id - 110), p=player:
-                                     state.has(ln, p, num) and ready_for_late_game(state, player, world))
+                            set_rule(
+                                world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                lambda state, ln="Progressive Sky Peak", num=(location.id - 110), p=player: state.has(
+                                    ln, p, num
+                                )
+                                and ready_for_late_game(state, player, world),
+                            )
                             if special_episode_sanity_no_exclusion(world, player):
-                                add_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                         lambda state: state.has("Main Game Unlock", player))
+                                add_rule(
+                                    world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                    lambda state: state.has("Main Game Unlock", player),
+                                )
 
                     elif world.options.sky_peak_type == 2:
                         for j in range(world.options.late_mission_checks.value):
-                            set_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                     lambda state, ln=location.name, p=player:
-                                     state.has(ln, p) and ready_for_late_game(state, player, world))
+                            set_rule(
+                                world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                lambda state, ln=location.name, p=player: state.has(ln, p)
+                                and ready_for_late_game(state, player, world),
+                            )
                             if special_episode_sanity_no_exclusion(world, player):
-                                add_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                         lambda state: state.has("Main Game Unlock", player))
+                                add_rule(
+                                    world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                    lambda state: state.has("Main Game Unlock", player),
+                                )
                         for j in range(world.options.late_outlaw_checks.value):
-                            set_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                     lambda state, ln=location.name, p=player:
-                                     state.has(ln, p) and ready_for_late_game(state, player, world))
+                            set_rule(
+                                world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                lambda state, ln=location.name, p=player: state.has(ln, p)
+                                and ready_for_late_game(state, player, world),
+                            )
                             if special_episode_sanity_no_exclusion(world, player):
-                                add_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                         lambda state: state.has("Main Game Unlock", player))
+                                add_rule(
+                                    world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                    lambda state: state.has("Main Game Unlock", player),
+                                )
 
                     elif world.options.sky_peak_type == 3:
                         for j in range(world.options.late_mission_checks.value):
-                            set_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                     lambda state, ln="1st Station Pass", p=player:
-                                     state.has(ln, p) and ready_for_late_game(state, player, world))
+                            set_rule(
+                                world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                lambda state, ln="1st Station Pass", p=player: state.has(ln, p)
+                                and ready_for_late_game(state, player, world),
+                            )
                             if special_episode_sanity_no_exclusion(world, player):
-                                add_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                         lambda state: state.has("Main Game Unlock", player))
+                                add_rule(
+                                    world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                    lambda state: state.has("Main Game Unlock", player),
+                                )
                         for j in range(world.options.late_outlaw_checks.value):
-                            set_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                     lambda state, ln="1st Station Pass", p=player:
-                                     state.has(ln, p) and ready_for_late_game(state, player, world))
+                            set_rule(
+                                world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                lambda state, ln="1st Station Pass", p=player: state.has(ln, p)
+                                and ready_for_late_game(state, player, world),
+                            )
                             if special_episode_sanity_no_exclusion(world, player):
-                                add_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                         lambda state: state.has("Main Game Unlock", player))
+                                add_rule(
+                                    world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                    lambda state: state.has("Main Game Unlock", player),
+                                )
 
                 elif location.name == "Hidden Land":
                     for j in range(world.options.late_mission_checks.value):
-                        set_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                 lambda state, ln=location.name, p=player: ready_for_late_game(state, p, world))
+                        set_rule(
+                            world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                            lambda state, ln=location.name, p=player: ready_for_late_game(state, p, world),
+                        )
                         if special_episode_sanity_no_exclusion(world, player):
-                            add_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                     lambda state: state.has("Main Game Unlock", player))
+                            add_rule(
+                                world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                lambda state: state.has("Main Game Unlock", player),
+                            )
 
                     for j in range(world.options.late_outlaw_checks.value):
-                        set_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                 lambda state, ln=location.name, p=player: ready_for_late_game(state, p, world))
+                        set_rule(
+                            world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                            lambda state, ln=location.name, p=player: ready_for_late_game(state, p, world),
+                        )
                         if special_episode_sanity_no_exclusion(world, player):
-                            add_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                     lambda state: state.has("Main Game Unlock", player))
+                            add_rule(
+                                world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                lambda state: state.has("Main Game Unlock", player),
+                            )
 
                 elif location.name == "The Nightmare":
                     for j in range(world.options.late_mission_checks.value):
-                        set_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                 lambda state, ln=location.name, p=player: ready_for_late_game(state, p, world)
-                                                                           and state.can_reach_location("Mt. Bristle", p)
-                                                                           and state.has(ln, p))
+                        set_rule(
+                            world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                            lambda state, ln=location.name, p=player: ready_for_late_game(state, p, world)
+                            and state.can_reach_location("Mt. Bristle", p)
+                            and state.has(ln, p),
+                        )
                         if special_episode_sanity_no_exclusion(world, player):
-                            add_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                     lambda state: state.has("Main Game Unlock", player))
+                            add_rule(
+                                world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                lambda state: state.has("Main Game Unlock", player),
+                            )
 
                     for j in range(world.options.late_outlaw_checks.value):
-                        set_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                 lambda state, ln=location.name, p=player: ready_for_late_game(state, p, world)
-                                                                           and state.can_reach_location("Mt. Bristle", p)
-                                                                           and state.has(ln, p))
+                        set_rule(
+                            world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                            lambda state, ln=location.name, p=player: ready_for_late_game(state, p, world)
+                            and state.can_reach_location("Mt. Bristle", p)
+                            and state.has(ln, p),
+                        )
                         if special_episode_sanity_no_exclusion(world, player):
-                            add_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                     lambda state: state.has("Main Game Unlock", player))
+                            add_rule(
+                                world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                lambda state: state.has("Main Game Unlock", player),
+                            )
 
                 else:
                     for j in range(world.options.late_mission_checks.value):
-                        set_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                 lambda state, ln=location.name, p=player:
-                                 state.has(ln, p) and ready_for_late_game(state, player, world))
+                        set_rule(
+                            world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                            lambda state, ln=location.name, p=player: state.has(ln, p)
+                            and ready_for_late_game(state, player, world),
+                        )
                         if special_episode_sanity_no_exclusion(world, player):
-                            add_rule(world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
-                                     lambda state: state.has("Main Game Unlock", player))
+                            add_rule(
+                                world.multiworld.get_location(f"{location.name} Mission {j + 1}", player),
+                                lambda state: state.has("Main Game Unlock", player),
+                            )
 
                     for j in range(world.options.late_outlaw_checks.value):
-                        set_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                 lambda state, ln=location.name, p=player:
-                                 state.has(ln, p) and ready_for_late_game(state, player, world))
+                        set_rule(
+                            world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                            lambda state, ln=location.name, p=player: state.has(ln, p)
+                            and ready_for_late_game(state, player, world),
+                        )
                         if special_episode_sanity_no_exclusion(world, player):
-                            add_rule(world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
-                                     lambda state: state.has("Main Game Unlock", player))
+                            add_rule(
+                                world.multiworld.get_location(f"{location.name} Outlaw {j + 1}", player),
+                                lambda state: state.has("Main Game Unlock", player),
+                            )
 
 
 def subx_rules(world, player):
     for item in subX_table:
         if item.flag_definition == "Unused" or item.default_item == "ignore":
             continue
-        if world.options.goal.value == 0 and item.classification in ["Manaphy", "LateSubX", "Legendary", "Instrument",
-                                                                      "SecretRank"]:
+        if world.options.goal.value == 0 and item.classification in [
+            "Manaphy",
+            "LateSubX",
+            "Legendary",
+            "Instrument",
+            "SecretRank",
+        ]:
             continue
-        if world.options.goal.value == 0 and item.flag_definition in ["Recycle Shop Dungeon #4",
-                                                                      "Recycle Shop Dungeon #5"]:
+        if world.options.goal.value == 0 and item.flag_definition in [
+            "Recycle Shop Dungeon #4",
+            "Recycle Shop Dungeon #5",
+        ]:
             continue
         if world.options.goal.value == 0 and item.flag_definition == "Bag Upgrade 5":
             continue
         # if world.options.long_location.value == 0 and item.classification in ["OptionalSubX"]:
         #   continue
         if item.classification == "Rank":
-            rank_toid_dict = {"Bronze Rank": 1, "Silver Rank": 2, "Gold Rank": 3, "Diamond Rank": 4, "Super Rank": 5,
-                              "Ultra Rank": 6, "Hyper Rank": 7, "Master Rank": 8, "Master ★ Rank": 9,
-                              "Master ★★ Rank": 10, "Master ★★★ Rank": 11, "Guildmaster Rank": 12}
+            rank_toid_dict = {
+                "Bronze Rank": 1,
+                "Silver Rank": 2,
+                "Gold Rank": 3,
+                "Diamond Rank": 4,
+                "Super Rank": 5,
+                "Ultra Rank": 6,
+                "Hyper Rank": 7,
+                "Master Rank": 8,
+                "Master ★ Rank": 9,
+                "Master ★★ Rank": 10,
+                "Master ★★★ Rank": 11,
+                "Guildmaster Rank": 12,
+            }
             if rank_toid_dict[item.flag_definition] > world.options.max_rank:
                 continue
             # if dialga is the goal, we can't add master star rank+
             if world.options.goal.value == 0 and rank_toid_dict[item.flag_definition] > 8:
                 continue
-        if ((special_episode_sanity_no_exclusion(world, player)) and item.classification in ["Free", "ShopItem"]
-                and "Main Game" not in item.prerequisites):
-            add_rule(world.multiworld.get_location(item.flag_definition, player),
-                     lambda state: state.has("Main Game Unlock", player) or state.has("Bidoof\'s Wish", player)
-                                   or state.has('Today\'s "Oh My Gosh"', player))
+        if (
+            (special_episode_sanity_no_exclusion(world, player))
+            and item.classification in ["Free", "ShopItem"]
+            and "Main Game" not in item.prerequisites
+        ):
+            add_rule(
+                world.multiworld.get_location(item.flag_definition, player),
+                lambda state: state.has("Main Game Unlock", player)
+                or state.has("Bidoof's Wish", player)
+                or state.has('Today\'s "Oh My Gosh"', player),
+            )
         elif special_episode_sanity_no_exclusion(world, player):
-            add_rule(world.multiworld.get_location(item.flag_definition, player),
-                     lambda state: state.has("Main Game Unlock", player))
+            add_rule(
+                world.multiworld.get_location(item.flag_definition, player),
+                lambda state: state.has("Main Game Unlock", player),
+            )
         # if (item.flag_definition == "Manaphy's Discovery") and world.options.goal.value == 0:
         # continue
         for requirement in item.prerequisites:
             if requirement == "Defeat Dialga":
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state: ready_for_late_game(state, player, world))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state: ready_for_late_game(state, player, world),
+                )
             elif requirement == "Sky Peak Summit Pass":
                 if world.options.sky_peak_type == 1:
-                    add_rule(world.multiworld.get_location(item.flag_definition, player),
-                             lambda state, req="Progressive Sky Peak": ready_for_late_game(state, player, world)
-                                                                       and state.has(req, player, 10))
+                    add_rule(
+                        world.multiworld.get_location(item.flag_definition, player),
+                        lambda state, req="Progressive Sky Peak": ready_for_late_game(state, player, world)
+                        and state.has(req, player, 10),
+                    )
                 elif world.options.sky_peak_type == 2:
-                    add_rule(world.multiworld.get_location(item.flag_definition, player),
-                             lambda state, req="Sky Peak Summit Pass": ready_for_late_game(state, player, world)
-                                                                          and state.has(req, player))
+                    add_rule(
+                        world.multiworld.get_location(item.flag_definition, player),
+                        lambda state, req="Sky Peak Summit Pass": ready_for_late_game(state, player, world)
+                        and state.has(req, player),
+                    )
                 elif world.options.sky_peak_type == 3:
-                    add_rule(world.multiworld.get_location(item.flag_definition, player),
-                             lambda state, req="1st Station Pass": ready_for_late_game(state, player, world)
-                                                                   and state.has(req, player))
+                    add_rule(
+                        world.multiworld.get_location(item.flag_definition, player),
+                        lambda state, req="1st Station Pass": ready_for_late_game(state, player, world)
+                        and state.has(req, player),
+                    )
             elif requirement == "7th Station Pass":
                 if world.options.sky_peak_type == 1:
-                    add_rule(world.multiworld.get_location(item.flag_definition, player),
-                             lambda state, req="Progressive Sky Peak": ready_for_late_game(state, player, world)
-                                                                       and state.has(req, player, 7))
+                    add_rule(
+                        world.multiworld.get_location(item.flag_definition, player),
+                        lambda state, req="Progressive Sky Peak": ready_for_late_game(state, player, world)
+                        and state.has(req, player, 7),
+                    )
                 elif world.options.sky_peak_type == 2:
-                    add_rule(world.multiworld.get_location(item.flag_definition, player),
-                             lambda state, req="7th Station Pass": ready_for_late_game(state, player, world)
-                                                                   and state.has(req, player))
+                    add_rule(
+                        world.multiworld.get_location(item.flag_definition, player),
+                        lambda state, req="7th Station Pass": ready_for_late_game(state, player, world)
+                        and state.has(req, player),
+                    )
                 elif world.options.sky_peak_type == 3:
-                    add_rule(world.multiworld.get_location(item.flag_definition, player),
-                             lambda state, req="1st Station Pass": ready_for_late_game(state, player, world)
-                                                                   and state.has(req, player))
+                    add_rule(
+                        world.multiworld.get_location(item.flag_definition, player),
+                        lambda state, req="1st Station Pass": ready_for_late_game(state, player, world)
+                        and state.has(req, player),
+                    )
             elif requirement in ["ProgressiveBag1", "ProgressiveBag2", "ProgressiveBag3"]:
                 bag_num_str = requirement[-1]
                 bag_num = int(bag_num_str)
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req="Bag Upgrade", p=player, num=bag_num: state.has(req, p, num))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state, req="Bag Upgrade", p=player, num=bag_num: state.has(req, p, num),
+                )
 
             elif requirement in ["3 Early", "5 Early", "10 Early"]:
                 dungeon_num_str = requirement[0:2]
                 dungeon_num = int(dungeon_num_str)
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req="EarlyDungeons", p=player, num=dungeon_num: state.has_group(req, p, num))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state, req="EarlyDungeons", p=player, num=dungeon_num: state.has_group(req, p, num),
+                )
 
             elif requirement == "Hidden Land":
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req="Relic Fragment Shard", p=player,
-                                num=world.options.required_fragments.value: state.has(req, p, num))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state,
+                    req="Relic Fragment Shard",
+                    p=player,
+                    num=world.options.required_fragments.value: state.has(req, p, num),
+                )
             elif requirement == "Ice Seal" and world.options.cursed_aegis_cave.value == 0:
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req="Progressive Seal", p=player,
-                                num=1: state.has(req, p, num))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state, req="Progressive Seal", p=player, num=1: state.has(req, p, num),
+                )
 
             elif requirement == "Rock Seal" and world.options.cursed_aegis_cave.value == 0:
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req="Progressive Seal", p=player,
-                                num=2: state.has(req, p, num))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state, req="Progressive Seal", p=player, num=2: state.has(req, p, num),
+                )
 
             elif requirement == "Steel Seal" and world.options.cursed_aegis_cave.value == 0:
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req="Progressive Seal", p=player,
-                                num=3: state.has(req, p, num))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state, req="Progressive Seal", p=player, num=3: state.has(req, p, num),
+                )
 
             elif requirement == "All Mazes":
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req="Dojo Dungeons", p=player: state.has_group(req, p, 10))
-            elif requirement == "Bidoof\'s Wish":
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state, req="Dojo Dungeons", p=player: state.has_group(req, p, 10),
+                )
+            elif requirement == "Bidoof's Wish":
                 if world.options.exclude_special.value:
                     continue
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req=requirement, p=player: state.has(req, p))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state, req=requirement, p=player: state.has(req, p),
+                )
             elif requirement == "Main Game":
                 continue
             else:
-                add_rule(world.multiworld.get_location(item.flag_definition, player),
-                         lambda state, req=requirement, p=player: state.has(req, p))
+                add_rule(
+                    world.multiworld.get_location(item.flag_definition, player),
+                    lambda state, req=requirement, p=player: state.has(req, p),
+                )
 
 
 def special_episode_sanity_no_exclusion(world, player) -> bool:

--- a/worlds/pmd_eos/__init__.py
+++ b/worlds/pmd_eos/__init__.py
@@ -7,10 +7,23 @@ import settings
 import random
 from typing import List, Dict, Set, Any
 
-from .Items import (EOSItem, item_table, item_frequencies, item_table_by_id, item_table_by_groups,
-                    filler_item_table, filler_item_weights, trap_item_table, trap_item_weights,
-                    exclusive_filler_item_table, exclusive_filler_item_weights, legendary_pool_dict, filler_items,
-                    exclusive_filler_items, conditional_filler_useful_items)
+from .Items import (
+    EOSItem,
+    item_table,
+    item_frequencies,
+    item_table_by_id,
+    item_table_by_groups,
+    filler_item_table,
+    filler_item_weights,
+    trap_item_table,
+    trap_item_weights,
+    exclusive_filler_item_table,
+    exclusive_filler_item_weights,
+    legendary_pool_dict,
+    filler_items,
+    exclusive_filler_items,
+    conditional_filler_useful_items,
+)
 from .Locations import EOS_location_table, EOSLocation, location_Dict_by_id, expanded_EOS_location_table
 from .Options import EOSOptions
 from .Rules import set_rules, ready_for_late_game, has_relic_shards
@@ -25,14 +38,16 @@ class EOSWeb(WebWorld):
     theme = "ocean"
     game = "Pokemon Mystery Dungeon Explorers of Sky"
 
-    tutorials = [Tutorial(
-        "Multiworld Setup Guide",
-        "A Guide to setting up Explorers of Sky for MultiWorld.",
-        "English",
-        "setup_en.md",
-        "setup/en",
-        ["CrypticMonkey33", "Chesyon"]
-    )]
+    tutorials = [
+        Tutorial(
+            "Multiworld Setup Guide",
+            "A Guide to setting up Explorers of Sky for MultiWorld.",
+            "English",
+            "setup_en.md",
+            "setup/en",
+            ["CrypticMonkey33", "Chesyon"],
+        )
+    ]
 
 
 class EOSSettings(settings.Group):
@@ -59,10 +74,8 @@ class EOSWorld(World):
     web = EOSWeb()
     settings: typing.ClassVar[EOSSettings]
 
-    item_name_to_id = {item.name: item.id for
-                       item in item_table.values()}
-    location_name_to_id = {location.name: location.id for
-                           location in expanded_EOS_location_table}
+    item_name_to_id = {item.name: item.id for item in item_table.values()}
+    location_name_to_id = {location.name: location.id for location in expanded_EOS_location_table}
 
     required_client_version = (0, 6, 1)
     required_server_version = (0, 6, 1)
@@ -80,7 +93,7 @@ class EOSWorld(World):
 
     def get_filler_item_name(self) -> str:
         """Called when the item pool needs to be filled with additional items to match location count."""
-        #logging.warning(f"World {self} is generating a filler item without custom filler pool.")
+        # logging.warning(f"World {self} is generating a filler item without custom filler pool.")
         return self.multiworld.random.choice(tuple(filler_item_table.keys()))
 
     def generate_early(self) -> None:
@@ -107,8 +120,13 @@ class EOSWorld(World):
             item_name = "Formation Control"
             self.multiworld.push_precollected(self.create_item(item_name))
         if self.options.special_episode_sanity.value and not self.options.exclude_special.value:
-            possible_se = ["Bidoof\'s Wish", "Igglybuff the Prodigy", 'Today\'s "Oh My Gosh"', "Here Comes Team Charm!",
-                           "In the Future of Darkness"]
+            possible_se = [
+                "Bidoof's Wish",
+                "Igglybuff the Prodigy",
+                'Today\'s "Oh My Gosh"',
+                "Here Comes Team Charm!",
+                "In the Future of Darkness",
+            ]
             se_num = self.random.randint(0, 4)
             self.starting_se = se_num
             item_name = possible_se[se_num]
@@ -123,8 +141,8 @@ class EOSWorld(World):
         early_dungeons_region = Region("Early Dungeons", self.player, self.multiworld)
         self.multiworld.regions.append(early_dungeons_region)
 
-        #early_dungeons_region2 = Region("Early Dungeons2", self.player, self.multiworld)
-        #self.multiworld.regions.append(early_dungeons_region2)
+        # early_dungeons_region2 = Region("Early Dungeons2", self.player, self.multiworld)
+        # self.multiworld.regions.append(early_dungeons_region2)
 
         late_dungeons_region = Region("Late Dungeons", self.player, self.multiworld)
         self.multiworld.regions.append(late_dungeons_region)
@@ -140,39 +158,43 @@ class EOSWorld(World):
 
         for location in EOS_location_table:
             if location.name == "Beach Cave":
-                menu_region.locations.append(EOSLocation(self.player, location.name,
-                                                         location.id, menu_region))
+                menu_region.locations.append(EOSLocation(self.player, location.name, location.id, menu_region))
                 if "Mission" in location.group:
                     for j in range(self.options.early_mission_checks.value):
                         location_name: str = f"{location.name} Mission {j + 1}"
                         location_id = location.id + self.mission_start_id + (100 * location.id) + j
-                        menu_region.locations.append(EOSLocation(self.player, location_name,
-                                                                 location_id, menu_region))
+                        menu_region.locations.append(EOSLocation(self.player, location_name, location_id, menu_region))
 
                         self.extra_locations_added += 1
                     for j in range(self.options.early_outlaw_checks.value):
                         location_name = f"{location.name} Outlaw {j + 1}"
                         location_id = location.id + self.mission_start_id + (100 * location.id) + j + 50
-                        menu_region.locations.append(EOSLocation(self.player, location_name,
-                                                                 location_id, menu_region))
+                        menu_region.locations.append(EOSLocation(self.player, location_name, location_id, menu_region))
 
                         self.extra_locations_added += 1
             elif location.classification == "Free":
-                menu_region.locations.append(EOSLocation(self.player, location.name,
-                                                         location.id, menu_region))
+                menu_region.locations.append(EOSLocation(self.player, location.name, location.id, menu_region))
             elif location.name == "Team Name Location":
-                menu_region.locations.append(EOSLocation(self.player, location.name,
-                                                         location.id, menu_region))
+                menu_region.locations.append(EOSLocation(self.player, location.name, location.id, menu_region))
             elif location.classification == "Rank":
-                rank_toid_dict = {"Bronze Rank": 1, "Silver Rank": 2, "Gold Rank": 3, "Diamond Rank": 4,
-                                  "Super Rank": 5,
-                                  "Ultra Rank": 6, "Hyper Rank": 7, "Master Rank": 8, "Master ★ Rank": 9,
-                                  "Master ★★ Rank": 10, "Master ★★★ Rank": 11, "Guildmaster Rank": 12}
+                rank_toid_dict = {
+                    "Bronze Rank": 1,
+                    "Silver Rank": 2,
+                    "Gold Rank": 3,
+                    "Diamond Rank": 4,
+                    "Super Rank": 5,
+                    "Ultra Rank": 6,
+                    "Hyper Rank": 7,
+                    "Master Rank": 8,
+                    "Master ★ Rank": 9,
+                    "Master ★★ Rank": 10,
+                    "Master ★★★ Rank": 11,
+                    "Guildmaster Rank": 12,
+                }
                 if rank_toid_dict[location.name] > self.options.max_rank:
                     # self.excluded_locations += 1
                     # continue
-                    early_dungeon = EOSLocation(self.player, location.name,
-                                                                       location.id, early_dungeons_region)
+                    early_dungeon = EOSLocation(self.player, location.name, location.id, early_dungeons_region)
                     early_dungeon.progress_type = LocationProgressType.EXCLUDED
                     self.excluded_tag_amount += 1
                     early_dungeons_region.locations.append(early_dungeon)
@@ -182,55 +204,61 @@ class EOSWorld(World):
                     # self.excluded_locations += 1
                     # continue
 
-                    late_dungeon = EOSLocation(self.player, location.name,
-                                               location.id, late_dungeons_region)
+                    late_dungeon = EOSLocation(self.player, location.name, location.id, late_dungeons_region)
                     late_dungeon.progress_type = LocationProgressType.EXCLUDED
                     self.excluded_tag_amount += 1
                     late_dungeons_region.locations.append(late_dungeon)
 
                 elif rank_toid_dict[location.name] <= 8:
-                    early_dungeons_region.locations.append(EOSLocation(self.player, location.name,
-                                                                       location.id, early_dungeons_region))
+                    early_dungeons_region.locations.append(
+                        EOSLocation(self.player, location.name, location.id, early_dungeons_region)
+                    )
                 else:
-                    late_dungeon = EOSLocation(self.player, location.name,
-                                               location.id, late_dungeons_region)
+                    late_dungeon = EOSLocation(self.player, location.name, location.id, late_dungeons_region)
                     late_dungeons_region.locations.append(late_dungeon)
 
             elif location.classification in ["EarlyDungeonComplete", "EarlySubX"]:
-                early_dungeons_region.locations.append(EOSLocation(self.player, location.name,
-                                                                   location.id, early_dungeons_region))
+                early_dungeons_region.locations.append(
+                    EOSLocation(self.player, location.name, location.id, early_dungeons_region)
+                )
                 if "Mission" in location.group:
                     for j in range(self.options.early_mission_checks.value):
                         location_name = f"{location.name} Mission {j + 1}"
                         location_id = location.id + self.mission_start_id + (100 * location.id) + j
-                        early_dungeons_region.locations.append(EOSLocation(self.player, location_name,
-                                                                           location_id, early_dungeons_region))
+                        early_dungeons_region.locations.append(
+                            EOSLocation(self.player, location_name, location_id, early_dungeons_region)
+                        )
 
-                        set_rule(self.multiworld.get_location(location_name, self.player),
-                                 lambda state, ln=location.name, p=self.player: state.has(ln, p))
+                        set_rule(
+                            self.multiworld.get_location(location_name, self.player),
+                            lambda state, ln=location.name, p=self.player: state.has(ln, p),
+                        )
                         self.extra_locations_added += 1
 
                     for j in range(self.options.early_outlaw_checks.value):
                         location_name = f"{location.name} Outlaw {j + 1}"
                         location_id = location.id + self.mission_start_id + (100 * location.id) + j + 50
-                        early_dungeons_region.locations.append(EOSLocation(self.player, location_name,
-                                                                           location_id, early_dungeons_region))
+                        early_dungeons_region.locations.append(
+                            EOSLocation(self.player, location_name, location_id, early_dungeons_region)
+                        )
 
-                        set_rule(self.multiworld.get_location(location_name, self.player),
-                                 lambda state, ln=location.name, p=self.player: state.has(ln, p))
+                        set_rule(
+                            self.multiworld.get_location(location_name, self.player),
+                            lambda state, ln=location.name, p=self.player: state.has(ln, p),
+                        )
                         self.extra_locations_added += 1
 
             elif location.classification == "SpecialDungeonComplete":
                 if not self.options.exclude_special.value:
-                    early_dungeons_region.locations.append(EOSLocation(self.player, location.name,
-                                                                   location.id, early_dungeons_region))
+                    early_dungeons_region.locations.append(
+                        EOSLocation(self.player, location.name, location.id, early_dungeons_region)
+                    )
                 else:
                     self.excluded_locations += 1
                     continue
 
             elif location.classification in ["LateDungeonComplete", "LateSubX"]:
-                late_dungeon = EOSLocation(self.player, location.name,
-                                           location.id, late_dungeons_region)
+                late_dungeon = EOSLocation(self.player, location.name, location.id, late_dungeons_region)
                 if self.options.goal.value == 0:  # if dialga is the goal, make the location excluded
                     self.excluded_locations += 1
                     continue
@@ -240,51 +268,56 @@ class EOSWorld(World):
                     for j in range(self.options.late_mission_checks.value):
                         location_name = f"{location.name} Mission {j + 1}"
                         location_id = location.id + self.mission_start_id + (100 * location.id) + j
-                        late_dungeons_region.locations.append(EOSLocation(self.player, location_name,
-                                                                          location_id, late_dungeons_region))
+                        late_dungeons_region.locations.append(
+                            EOSLocation(self.player, location_name, location_id, late_dungeons_region)
+                        )
 
-                        set_rule(self.multiworld.get_location(f"{location.name} Mission {j + 1}", self.player),
-                                 lambda state, ln=location.name, p=self.player: state.has(ln, p))
+                        set_rule(
+                            self.multiworld.get_location(f"{location.name} Mission {j + 1}", self.player),
+                            lambda state, ln=location.name, p=self.player: state.has(ln, p),
+                        )
                         self.extra_locations_added += 1
 
                     for j in range(self.options.late_outlaw_checks.value):
                         location_name = f"{location.name} Outlaw {j + 1}"
                         location_id = location.id + self.mission_start_id + (100 * location.id) + j + 50
-                        late_dungeons_region.locations.append(EOSLocation(self.player, location_name,
-                                                                          location_id, late_dungeons_region))
+                        late_dungeons_region.locations.append(
+                            EOSLocation(self.player, location_name, location_id, late_dungeons_region)
+                        )
 
-                        set_rule(self.multiworld.get_location(f"{location.name} Outlaw {j + 1}", self.player),
-                                 lambda state, ln=location.name, p=self.player: state.has(ln, p))
+                        set_rule(
+                            self.multiworld.get_location(f"{location.name} Outlaw {j + 1}", self.player),
+                            lambda state, ln=location.name, p=self.player: state.has(ln, p),
+                        )
 
                         self.extra_locations_added += 1
-            elif (location.classification in ["Manaphy", "SecretRank", "Legendary", "Instrument"]
-                  or location.name in ["Bag Upgrade 5", "Recycle Shop Dungeon #4", "Recycle Shop Dungeon #5"]):
-                late_dungeon = EOSLocation(self.player, location.name,
-                                           location.id, late_dungeons_region)
+            elif location.classification in ["Manaphy", "SecretRank", "Legendary", "Instrument"] or location.name in [
+                "Bag Upgrade 5",
+                "Recycle Shop Dungeon #4",
+                "Recycle Shop Dungeon #5",
+            ]:
+                late_dungeon = EOSLocation(self.player, location.name, location.id, late_dungeons_region)
                 if self.options.goal.value == 0:  # if dialga is the goal, make the location excluded
                     self.excluded_locations += 1
                     continue
-                    #late_dungeon.progress_type = LocationProgressType.EXCLUDED
-                    #Manaphy's discovery can only be collected if manaphy is in the game
-                    #if location.name == "Manaphy's Discovery":
+                    # late_dungeon.progress_type = LocationProgressType.EXCLUDED
+                    # Manaphy's discovery can only be collected if manaphy is in the game
+                    # if location.name == "Manaphy's Discovery":
                     #    continue
                 late_dungeons_region.locations.append(late_dungeon)
             elif location.classification == "SpindaDrinkEvent":
                 if int(location.name[-2:]) <= self.options.drink_events:
-                    menu_region.locations.append(EOSLocation(self.player, location.name,
-                                                             location.id, menu_region))
+                    menu_region.locations.append(EOSLocation(self.player, location.name, location.id, menu_region))
                 else:
                     self.excluded_locations += 1
             elif location.classification == "SpindaDrink":
                 if int(location.name[-2:]) <= self.options.spinda_drinks:
-                    menu_region.locations.append(EOSLocation(self.player, location.name,
-                                                             location.id, menu_region))
+                    menu_region.locations.append(EOSLocation(self.player, location.name, location.id, menu_region))
                 else:
                     self.excluded_locations += 1
 
             elif location.classification == "BossDungeonComplete":
-                location_data = EOSLocation(self.player, location.name,
-                                            location.id, end_game_region)
+                location_data = EOSLocation(self.player, location.name, location.id, end_game_region)
                 if location.name == "Dark Crater" and self.options.goal.value == 0:
                     location_data.progress_type = LocationProgressType.EXCLUDED
 
@@ -293,35 +326,45 @@ class EOSWorld(World):
                     for j in range(self.options.late_mission_checks.value):
                         location_name = f"{location.name} Mission {j + 1}"
                         location_id = location.id + self.mission_start_id + (100 * location.id) + j
-                        late_dungeons_region.locations.append(EOSLocation(self.player, location_name,
-                                                                          location_id, late_dungeons_region))
+                        late_dungeons_region.locations.append(
+                            EOSLocation(self.player, location_name, location_id, late_dungeons_region)
+                        )
 
-                        set_rule(self.multiworld.get_location(f"{location.name} Mission {j + 1}", self.player),
-                                 lambda state, ln=location.name, p=self.player: state.has(ln, p))
+                        set_rule(
+                            self.multiworld.get_location(f"{location.name} Mission {j + 1}", self.player),
+                            lambda state, ln=location.name, p=self.player: state.has(ln, p),
+                        )
                         self.extra_locations_added += 1
 
                     for j in range(self.options.late_outlaw_checks.value):
                         location_name = f"{location.name} Outlaw {j + 1}"
                         location_id = location.id + self.mission_start_id + (100 * location.id) + j + 50
-                        late_dungeons_region.locations.append(EOSLocation(self.player, location_name,
-                                                                          location_id, late_dungeons_region))
+                        late_dungeons_region.locations.append(
+                            EOSLocation(self.player, location_name, location_id, late_dungeons_region)
+                        )
 
-                        set_rule(self.multiworld.get_location(f"{location.name} Outlaw {j + 1}", self.player),
-                                 lambda state, ln=location.name, p=self.player: state.has(ln, p))
+                        set_rule(
+                            self.multiworld.get_location(f"{location.name} Outlaw {j + 1}", self.player),
+                            lambda state, ln=location.name, p=self.player: state.has(ln, p),
+                        )
 
                         self.extra_locations_added += 1
-            elif ((location.classification == "ProgressiveBagUpgrade") or (location.classification == "ShopItem")
-                  or (location.classification == "DojoDungeonComplete") or (
-                          location.classification == "SEDungeonUnlock")):
-                extra_items_region.locations.append(EOSLocation(self.player, location.name,
-                                                                location.id, extra_items_region))
+            elif (
+                (location.classification == "ProgressiveBagUpgrade")
+                or (location.classification == "ShopItem")
+                or (location.classification == "DojoDungeonComplete")
+                or (location.classification == "SEDungeonUnlock")
+            ):
+                extra_items_region.locations.append(
+                    EOSLocation(self.player, location.name, location.id, extra_items_region)
+                )
             elif location.classification in ["RuleDungeonComplete"]:
                 if self.options.long_location.value == 0:
                     self.excluded_locations += 1
                     continue
-                    #location = EOSLocation(self.player, location.name, location.id, rule_dungeons_region)
-                    #location.progress_type = LocationProgressType.EXCLUDED
-                    #rule_dungeons_region.locations.append(location)
+                    # location = EOSLocation(self.player, location.name, location.id, rule_dungeons_region)
+                    # location.progress_type = LocationProgressType.EXCLUDED
+                    # rule_dungeons_region.locations.append(location)
                 else:
                     location = EOSLocation(self.player, location.name, location.id, rule_dungeons_region)
                     rule_dungeons_region.locations.append(location)
@@ -342,17 +385,17 @@ class EOSWorld(World):
 
         early_dungeons_region.connect(late_dungeons_region, "Late Game Door")
 
-        #early_dungeons_region.connect(early_dungeons_region2)
+        # early_dungeons_region.connect(early_dungeons_region2)
 
         late_dungeons_region.connect(end_game_region, "Boss Door")
-        #lambda state: ready_for_final_boss(state, self.player))
+        # lambda state: ready_for_final_boss(state, self.player))
 
         boss_region = Region("Boss Room", self.player, self.multiworld)
 
         boss_region.locations.append(EOSLocation(self.player, "Final Boss", None, boss_region))
 
         end_game_region.connect(boss_region, "End Game")
-        #lambda state: state.has("Temporal Tower", self.player))
+        # lambda state: state.has("Temporal Tower", self.player))
         late_dungeons_region.connect(rule_dungeons_region, "Rule Dungeons")
 
         self.get_location("Final Boss").place_locked_item(self.create_item("Victory"))
@@ -365,7 +408,6 @@ class EOSWorld(World):
             return EOSItem(item_data.name, item_data.classification, item_data.id, self.player)
 
     def fill_slot_data(self) -> Dict[str, Any]:
-
         return {
             "Goal": self.options.goal.value,
             "ServerVersion": game_version,
@@ -454,8 +496,9 @@ class EOSWorld(World):
             relics_to_add = self.options.total_shards.value
 
         for i in range(relics_to_add):
-            required_items.append(self.create_item("Relic Fragment Shard",
-                                                   ItemClassification.progression_skip_balancing))
+            required_items.append(
+                self.create_item("Relic Fragment Shard", ItemClassification.progression_skip_balancing)
+            )
 
         if self.options.goal == 1:
             required_items.append(self.create_item("Manaphy", ItemClassification.progression))
@@ -464,25 +507,32 @@ class EOSWorld(World):
             # self.excluded_locations += 1
             test = 0
         if self.options.goal.value == 1 and (
-                self.options.legendaries.value > len(self.options.allowed_legendaries.value)):
+            self.options.legendaries.value > len(self.options.allowed_legendaries.value)
+        ):
             for item in self.options.allowed_legendaries.value:
                 required_items.append(self.create_item(item, ItemClassification.filler))
         elif self.options.goal.value == 1:
-            new_list = self.random.sample(sorted(self.options.allowed_legendaries.value),
-                                          self.options.legendaries.value)
+            new_list = self.random.sample(
+                sorted(self.options.allowed_legendaries.value), self.options.legendaries.value
+            )
             for item in new_list:
                 required_items.append(self.create_item(item, ItemClassification.filler))
 
         for item_name in item_table:
-            #if (item_name == "Dark Crater") and (self.options.goal.value == 1):
-                #continue
+            # if (item_name == "Dark Crater") and (self.options.goal.value == 1):
+            # continue
             if item_name in item_frequencies:
                 freq = 0
 
                 freq = item_frequencies.get(item_name, 1)
 
-                freq = max(freq - precollected.count(item_name) + precollected_added.count(item_name)
-                           + precollected_from_pool.count(item_name), 0)
+                freq = max(
+                    freq
+                    - precollected.count(item_name)
+                    + precollected_added.count(item_name)
+                    + precollected_from_pool.count(item_name),
+                    0,
+                )
                 required_items += [self.create_item(item_name) for _ in range(freq)]
             elif "Special Dungeons" in item_table[item_name].group:
                 if self.options.exclude_special.value:
@@ -505,7 +555,7 @@ class EOSWorld(World):
                 continue
             elif item_table[item_name].name in conditional_filler_useful_items:
                 conditional_count += 1
-                #conditional_item_table.append(item_name)
+                # conditional_item_table.append(item_name)
                 continue
             elif item_table[item_name].classification == ItemClassification.filler:
                 if item_name in ["Gold Ribbon"]:
@@ -529,14 +579,14 @@ class EOSWorld(World):
                 classification = ItemClassification.progression
                 if (self.options.goal.value == 0) and "LateDungeons" in item_table[item_name].group:
                     continue
-                    #classification = ItemClassification.useful
+                    # classification = ItemClassification.useful
 
                 if (self.options.long_location.value == 0) and "RuleDungeons" in item_table[item_name].group:
                     continue
 
                 if "Aegis" in item_table[item_name].group:
                     if self.options.goal.value == 0:
-                        #classification = ItemClassification.useful
+                        # classification = ItemClassification.useful
                         continue
                     else:
                         classification = ItemClassification.progression
@@ -559,7 +609,7 @@ class EOSWorld(World):
                         if item_name == "Progressive Sky Peak":
                             if self.options.goal.value == 0:
                                 continue
-                                #classification = ItemClassification.useful
+                                # classification = ItemClassification.useful
                             else:
                                 classification = ItemClassification.progression
                             for i in range(10):
@@ -572,7 +622,7 @@ class EOSWorld(World):
                             continue
                         else:
                             if self.options.goal.value == 0:
-                                #classification = ItemClassification.useful
+                                # classification = ItemClassification.useful
                                 continue
                             else:
                                 classification = ItemClassification.progression
@@ -580,7 +630,7 @@ class EOSWorld(World):
                         if item_name == "1st Station Pass":
                             if self.options.goal.value == 0:
                                 continue
-                                #classification = ItemClassification.useful
+                                # classification = ItemClassification.useful
                             else:
                                 classification = ItemClassification.progression
 
@@ -592,15 +642,19 @@ class EOSWorld(World):
             else:
                 required_items.append(self.create_item(item_name, ItemClassification.useful))
 
-        remaining = len(EOS_location_table) + self.extra_locations_added - len(
-            required_items) - conditional_count - 1 - self.excluded_locations  # subtracting 1 for the event check
+        remaining = (
+            len(EOS_location_table)
+            + self.extra_locations_added
+            - len(required_items)
+            - conditional_count
+            - 1
+            - self.excluded_locations
+        )  # subtracting 1 for the event check
         for i in range(len(conditional_filler_useful_items)):
-            if (i <= (self.excluded_tag_amount-remaining)) and (remaining < self.excluded_tag_amount):
-                required_items.append(
-                    self.create_item(conditional_filler_useful_items[i], ItemClassification.filler))
+            if (i <= (self.excluded_tag_amount - remaining)) and (remaining < self.excluded_tag_amount):
+                required_items.append(self.create_item(conditional_filler_useful_items[i], ItemClassification.filler))
             else:
-                required_items.append(
-                    self.create_item(conditional_filler_useful_items[i], ItemClassification.useful))
+                required_items.append(self.create_item(conditional_filler_useful_items[i], ItemClassification.useful))
 
         self.multiworld.itempool += required_items
 
@@ -622,19 +676,28 @@ class EOSWorld(World):
         if self.options.allow_traps.value in [1, 2]:
             filler_items_toadd = math.ceil(remaining * (100 - self.options.trap_percent) / 100)
             traps_toadd = math.floor(remaining * self.options.trap_percent / 100)
-            self.multiworld.itempool += [self.create_item(filler_item.name) for filler_item
-                                         in self.random.sample(filler_items_pool, filler_items_toadd, counts=item_weights)]
-            self.multiworld.itempool += [self.create_item(trap.name) for trap
-                                         in self.random.sample(all_traps, traps_toadd, counts=all_trap_weights)]
+            self.multiworld.itempool += [
+                self.create_item(filler_item.name)
+                for filler_item in self.random.sample(filler_items_pool, filler_items_toadd, counts=item_weights)
+            ]
+            self.multiworld.itempool += [
+                self.create_item(trap.name)
+                for trap in self.random.sample(all_traps, traps_toadd, counts=all_trap_weights)
+            ]
 
         else:
-            self.multiworld.itempool += [self.create_item(filler_item.name) for filler_item
-                                         in self.random.sample(filler_items_pool, remaining, counts=item_weights)]
+            self.multiworld.itempool += [
+                self.create_item(filler_item.name)
+                for filler_item in self.random.sample(filler_items_pool, remaining, counts=item_weights)
+            ]
 
-        idek_var=self.excluded_tag_amount
-        wtf_items_list=[item.name for item in self.multiworld.itempool]
-        excluded_location_list = [location.name for location in self.multiworld.get_locations(self.player) if
-                                  location.progress_type is LocationProgressType.EXCLUDED]
+        idek_var = self.excluded_tag_amount
+        wtf_items_list = [item.name for item in self.multiworld.itempool]
+        excluded_location_list = [
+            location.name
+            for location in self.multiworld.get_locations(self.player)
+            if location.progress_type is LocationProgressType.EXCLUDED
+        ]
         test = 0
 
     def set_rules(self) -> None:
@@ -657,12 +720,11 @@ class EOSWorld(World):
             hint_item_list += [self.multiworld.get_location(f"Shop Item {1 + i}", self.player)]
         write_tokens(self, patch, hint_item_list, self.dimensional_scream_list, self.starting_se + 1)
         rom_path = os.path.join(
-            output_directory, f"{self.multiworld.get_out_file_name_base(self.player)}" f"{patch.patch_file_ending}"
+            output_directory, f"{self.multiworld.get_out_file_name_base(self.player)}{patch.patch_file_ending}"
         )
         patch.write(rom_path)
 
     def hint_locations(self) -> list[Location]:
-
         hint_loc = []
         filler = 5
         useful = 6
@@ -673,11 +735,29 @@ class EOSWorld(World):
         external_items = []
         extra_useful_items = []
         extra_filler_items = []
-        important_sky_items = ["Icy Flute", "Fiery Drum", "Terra Cymbal", "Aqua-Monica", "Rock Horn",
-                               "Grass Cornet", "Sky Melodica", "Stellar Symphony", "Null Bagpipes", "Glimmer Harp",
-                               "Toxic Sax", "Biting Bass", "Knockout Bell", "Spectral Chimes", "Liar's Lyre",
-                               "Charge Synth", "Norma-ccordion", "Psychic Cello", "Dragu-teki", "Steel Guitar",
-                               "Relic Fragment Shard"]
+        important_sky_items = [
+            "Icy Flute",
+            "Fiery Drum",
+            "Terra Cymbal",
+            "Aqua-Monica",
+            "Rock Horn",
+            "Grass Cornet",
+            "Sky Melodica",
+            "Stellar Symphony",
+            "Null Bagpipes",
+            "Glimmer Harp",
+            "Toxic Sax",
+            "Biting Bass",
+            "Knockout Bell",
+            "Spectral Chimes",
+            "Liar's Lyre",
+            "Charge Synth",
+            "Norma-ccordion",
+            "Psychic Cello",
+            "Dragu-teki",
+            "Steel Guitar",
+            "Relic Fragment Shard",
+        ]
         location_list = list(self.multiworld.get_locations(self.player))
         random.shuffle(location_list)
         for location in location_list:
@@ -720,10 +800,14 @@ class EOSWorld(World):
                         if i - len(sky_dungeons) - len(external_items) < len(extra_useful_items):
                             hint_loc.append(extra_useful_items[i - len(sky_dungeons) - len(external_items)])
                         else:
-                            if (i - len(sky_dungeons) - len(external_items) -
-                                    len(extra_useful_items) < len(extra_filler_items)):
-                                hint_loc.append(extra_filler_items[i - len(sky_dungeons) - len(external_items) -
-                                                                   len(extra_useful_items)])
+                            if i - len(sky_dungeons) - len(external_items) - len(extra_useful_items) < len(
+                                extra_filler_items
+                            ):
+                                hint_loc.append(
+                                    extra_filler_items[
+                                        i - len(sky_dungeons) - len(external_items) - len(extra_useful_items)
+                                    ]
+                                )
                             else:
                                 break
 


### PR DESCRIPTION
Reformat/lint with Ruff; the repo has a [ruff.toml](https://github.com/CrypticMonkey33/ArchipelagoExplorersOfSky/blob/main/ruff.toml) file, so Ruff is clearly *expected* to be used, even if most files on the repo don't comply with ruff.toml for some reason.