### PR TITLE
Use proper game title

### DIFF
--- a/worlds/pmd_eos/Client.py
+++ b/worlds/pmd_eos/Client.py
@@ -23,7 +23,7 @@ game_version = "v0.3.2"
 
 class EoSClient(BizHawkClient):
     logger = logging.getLogger("Client")
-    game = "Pokemon Mystery Dungeon Explorers of Sky"
+    game = "Pokémon Mystery Dungeon: Explorers of Sky"
     system = "NDS"
     patch_suffix = ".apeos"
     goal_flag: int

--- a/worlds/pmd_eos/Items.py
+++ b/worlds/pmd_eos/Items.py
@@ -18,7 +18,7 @@ class ItemData(NamedTuple):
 # Game specific Item that extends the Archipelago Item. Only thing this changes is sets the game name so that AP knows
 # what game the item comes from
 class EOSItem(Item):
-    game: str = "Pokemon Mystery Dungeon Explorers of Sky"
+    game: str = "Pokémon Mystery Dungeon: Explorers of Sky"
 
 
 # Make a dictionary that separates the item table based on the different groups for being able to search for all items

--- a/worlds/pmd_eos/Locations.py
+++ b/worlds/pmd_eos/Locations.py
@@ -25,7 +25,7 @@ class LocationData:
 
 
 class EOSLocation(Location):
-    game: str = "Pokemon Mystery Dungeon Explorers of Sky"
+    game: str = "Pokémon Mystery Dungeon: Explorers of Sky"
 
 
 def get_location_table_by_groups() -> Dict[str, set[str]]:

--- a/worlds/pmd_eos/Rom.py
+++ b/worlds/pmd_eos/Rom.py
@@ -16,12 +16,12 @@ def get_base_rom_as_bytes() -> bytes:
 
 
 class EOSPathExtension(APPatchExtension):
-    game = "Pokemon Mystery Dungeon Explorers of Sky"
+    game = "Pokémon Mystery Dungeon: Explorers of Sky"
 
 
 class EOSProcedurePatch(APProcedurePatch, APTokenMixin):
     # settings for what the end file is going to look like
-    game = "Pokemon Mystery Dungeon Explorers of Sky"
+    game = "Pokémon Mystery Dungeon: Explorers of Sky"
     hash = "6735749e060e002efd88e61560e45567"
     patch_file_ending = ".apeos"
     result_file_ending = ".nds"

--- a/worlds/pmd_eos/__init__.py
+++ b/worlds/pmd_eos/__init__.py
@@ -36,7 +36,7 @@ from .Rom import EOSProcedurePatch, write_tokens
 
 class EOSWeb(WebWorld):
     theme = "ocean"
-    game = "Pokemon Mystery Dungeon Explorers of Sky"
+    game = "Pokémon Mystery Dungeon: Explorers of Sky"
 
     tutorials = [
         Tutorial(
@@ -64,11 +64,11 @@ class EOSSettings(settings.Group):
 
 class EOSWorld(World):
     """
-    This is for Pokemon Mystery Dungeon Explorers of Sky, a game where you inhabit a pokemon and explore
+    This is for Pokémon Mystery Dungeon: Explorers of Sky, a game where you inhabit a pokemon and explore
     through dungeons, solve quests, and help out other Pokemon in the colony
     """
 
-    game = "Pokemon Mystery Dungeon Explorers of Sky"
+    game = "Pokémon Mystery Dungeon: Explorers of Sky"
     options: EOSOptions
     options_dataclass = EOSOptions
     web = EOSWeb()

--- a/worlds/pmd_eos/test/__init__.py
+++ b/worlds/pmd_eos/test/__init__.py
@@ -2,4 +2,4 @@ from test.bases import WorldTestBase
 
 
 class EOSTestBase(WorldTestBase):
-    game = "Pokemon Mystery Dungeon: Explorers of Sky"
+    game = "Pokémon Mystery Dungeon: Explorers of Sky"


### PR DESCRIPTION
The proper title for the game is `Pokémon Mystery Dungeon: Explorers of Sky`. Currently, the world refers to it as `Pokemon Mystery Dungeon Explorers of Sky`, which is missing the accented e and colon. This PR corrects all instances of the title to its proper format.